### PR TITLE
Fix admin dialogs and add pagination

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
 # .env
 NEXT_PUBLIC_API_URL=http://localhost:3001
+API_INTERNAL_URL=http://localhost:3001
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/industria
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=supersecretkey123456789

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # .env.example
 NEXT_PUBLIC_API_URL=http://localhost:3001
+API_INTERNAL_URL=http://localhost:3001
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/industria
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=your-secret-key-here-change-in-production

--- a/Back-End/README.md
+++ b/Back-End/README.md
@@ -13,3 +13,34 @@ npm run dev
 ```
 
 The server listens on port 3001 by default and connects to PostgreSQL using `DATABASE_URL`.
+
+### CORS
+
+Every API handler adds permissive CORS headers using a small helper. Requests from
+the frontend running on `localhost:3000` therefore succeed without additional
+configuration.
+
+## Populate the database with initDB.sql
+
+A helper script is provided to run the SQL file located in `db/init/initDB.sql`.
+The helper will use the local `psql` command when available. If not, it falls
+back to running `psql` inside the `db` service defined in `docker-compose.yml`.
+Set the `PGPASSWORD` environment variable with your database password. Other
+connection parameters can be customised via `DB_HOST`, `DB_PORT`, `DB_USER` and
+`DB_NAME`.
+
+```bash
+export PGPASSWORD=postgres
+./scripts/run_initdb.sh
+```
+
+After running the script you can sign in with the following demo accounts:
+
+```
+- admin@zonespro.ma / password123
+- manager@zonespro.ma / password123
+- demo@entreprise.ma / password123
+```
+The SQL file also fills `zone_vertices` and `parcel_vertices` with Lambert
+coordinates so polygons can be drawn for each zone and parcel.
+

--- a/Back-End/db/init/initDB.sql
+++ b/Back-End/db/init/initDB.sql
@@ -1,266 +1,282 @@
 -- db/init/initDB.sql
--- Population des données de démonstration pour Industria
--- Les tables sont créées par Flask/SQLAlchemy
+-- Simplified demo data for Industria using Prisma schema
 
--- Vérifier que PostGIS est disponible
 CREATE EXTENSION IF NOT EXISTS postgis;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
--- Fonction pour vider les tables dans le bon ordre (respecting FK constraints)
-DO
-$$
+-- Ensure newer columns exist when the database was created from an older schema
+ALTER TABLE parcels
+  ADD COLUMN IF NOT EXISTS "isFree" BOOLEAN DEFAULT TRUE,
+  ADD COLUMN IF NOT EXISTS "isShowroom" BOOLEAN DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS cos FLOAT,
+  ADD COLUMN IF NOT EXISTS cus FLOAT;
+
+-- Optional tables to store Lambert coordinates for drawing polygons
+CREATE TABLE IF NOT EXISTS zone_vertices (
+  "zoneId" TEXT NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
+  seq INT NOT NULL,
+  "lambertX" FLOAT NOT NULL,
+  "lambertY" FLOAT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS parcel_vertices (
+  "parcelId" TEXT NOT NULL REFERENCES parcels(id) ON DELETE CASCADE,
+  seq INT NOT NULL,
+  "lambertX" FLOAT NOT NULL,
+  "lambertY" FLOAT NOT NULL
+);
+
+-- Clean tables in order
+DO $$
 DECLARE
-  -- Tables dans l'ordre inverse pour le nettoyage (enfants -> parents)
   tables text[] := ARRAY[
+    'zone_vertices', 'parcel_vertices',
     'zone_activities', 'parcel_amenities', 'appointments', 'parcels',
     'zones', 'zone_types', 'activities', 'amenities',
-    'appointment_status', 'regions', 'countries', 'activity_logs'
+    'regions', 'countries', 'activity_logs', 'users'
   ];
   tbl text;
 BEGIN
-  -- Attendre que les tables soient créées par Flask
-  -- Cette fonction sera exécutée après Flask
   RAISE NOTICE 'Starting data population...';
-  
-  -- Nettoyer les données existantes si les tables existent
   FOREACH tbl IN ARRAY tables LOOP
     IF to_regclass('public.' || tbl) IS NOT NULL THEN
       EXECUTE format('TRUNCATE TABLE public.%I RESTART IDENTITY CASCADE', tbl);
       RAISE NOTICE 'Cleaned table: %', tbl;
     END IF;
   END LOOP;
-END
-$$;
-
--- Basic reference data
-INSERT INTO countries (id, name, code) VALUES
-  (1, 'Maroc', 'MA')
-ON CONFLICT (id) DO NOTHING;
-
-INSERT INTO zone_types (id, name) VALUES
-  (1, 'privée'),
-  (2, 'public')
-ON CONFLICT (id) DO NOTHING;
-
-INSERT INTO regions (id, name, country_id) VALUES
-  (1, 'Tanger-Tétouan-Al Hoceïma', 1),
-  (2, 'L''Oriental',              1),
-  (3, 'Fès-Meknès',               1),
-  (4, 'Rabat-Salé-Kénitra',       1),
-  (5, 'Béni Mellal-Khénifra',     1),
-  (6, 'Casablanca-Settat',        1),
-  (7, 'Marrakech-Safi',           1),
-  (8, 'Drâa-Tafilalet',           1),
-  (9, 'Souss-Massa',              1),
-  (10,'Guelmim-Oued Noun',        1),
-  (11,'Laâyoune-Sakia El Hamra',  1),
-  (12,'Dakhla-Oued Ed-Dahab',     1)
-ON CONFLICT (id) DO NOTHING;
-
--- Supprimer l'insertion des roles - ils seront gérés par Keycloak
-
-INSERT INTO amenities (id, amenities_key, label, icon) VALUES
-  (1, 'electricity', 'Électricité', '<svg viewBox="0 0 24 24"><path d="M7 2v11h3v9l7-12h-4l4-8z"/></svg>'),
-  (2, 'water', 'Eau potable', '<svg viewBox="0 0 24 24"><path d="M12 2c-5.33 4.55-8 8.48-8 11.8 0 4.98 3.8 8.2 8 8.2s8-3.22 8-8.2c0-3.32-2.67-7.25-8-11.8zM7.83 14c.37 0 .67.26.74.62.41 2.22 2.28 2.98 3.64 2.87.43-.02.79.32.79.75 0 .4-.32.73-.72.75-2.13.13-4.62-1.09-5.19-4.12a.75.75 0 01.74-.87z"/></svg>'),
-  (3, 'fiber', 'Fibre optique', '<svg viewBox="0 0 24 24"><path d="M9.93 13.5h4.14L12 7.98zM20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-3.05 16.5l-1.14-3H8.19l-1.14 3H5.96l5.11-13h1.86l5.11 13h-1.09z"/></svg>'),
-  (4, 'parking', 'Parking', '<svg viewBox="0 0 24 24"><path d="M13 3H6v18h4v-6h3c3.31 0 6-2.69 6-6s-2.69-6-6-6zm.2 8H10V7h3.2c1.1 0 2 .9 2 2s-.9 2-2 2z"/></svg>'),
-  (5, 'security', 'Sécurité 24/7', '<svg viewBox="0 0 24 24"><path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 10.99h7c-.53 4.12-3.28 7.79-7 8.94V12H5V6.3l7-3.11v8.8z"/></svg>')
-ON CONFLICT (id) DO UPDATE 
-SET icon = EXCLUDED.icon;
-
-INSERT INTO activities (id, activities_key, label, icon) VALUES
-  (1, 'industry', 'Industrie', '<svg viewBox="0 0 24 24"><path d="M18 3v2h-2V3H8v2H6V3H2v18h4v-2h2v2h8v-2h2v2h4V3h-4zM8 17H6v-2h2v2zm0-4H6v-2h2v2zm0-4H6V7h2v2zm10 8h-2v-2h2v2zm0-4h-2v-2h2v2zm0-4h-2V7h2v2z"/></svg>'),
-  (2, 'logistics', 'Logistique', '<svg viewBox="0 0 24 24"><path d="M20 8h-3V4H3c-1.1 0-2 .9-2 2v11h2c0 1.66 1.34 3 3 3s3-1.34 3-3h6c0 1.66 1.34 3 3 3s3-1.34 3-3h2v-5l-3-4zM6 18.5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zm13.5-9l1.96 2.5H17V9.5h2.5zm-1.5 9c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/></svg>'),
-  (3, 'commerce', 'Commerce', '<svg viewBox="0 0 24 24"><path d="M7 18c-1.1 0-1.99.9-1.99 2S5.9 22 7 22s2-.9 2-2-.9-2-2-2zM1 2v2h2l3.6 7.59-1.35 2.45c-.16.28-.25.61-.25.96 0 1.1.9 2 2 2h12v-2H7.42c-.14 0-.25-.11-.25-.25l.03-.12.9-1.63h7.45c.75 0 1.41-.41 1.75-1.03l3.58-6.49c.08-.14.12-.31.12-.48 0-.55-.45-1-1-1H5.21l-.94-2H1zm16 16c-1.1 0-1.99.9-1.99 2s.89 2 1.99 2 2-.9 2-2-.9-2-2-2z"/></svg>'),
-  (4, 'services', 'Services', '<svg viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>'),
-  (5, 'technology', 'Technologie', '<svg viewBox="0 0 24 24"><path d="M20 18c1.1 0 1.99-.9 1.99-2L22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2H0v2h24v-2h-4zM4 6h16v10H4V6z"/></svg>')
-ON CONFLICT (id) DO UPDATE 
-SET icon = EXCLUDED.icon;
-
-INSERT INTO appointment_status (id, status_name) VALUES
-  (1, 'Pending'),
-  (2, 'Confirmed'), 
-  (3, 'Canceled')
-ON CONFLICT (id) DO NOTHING;
-
--- Ajouter une zone de démonstration (comme dans votre fichier original)
-WITH ins AS (
-  INSERT INTO spatial_entities (entity_type, name, description, geometry)
-  VALUES (
-    'zone', 'PIAJ', 'Zone générée automatiquement pour les tests',
-    -- Conversion des coordonnées Lambert Nord Maroc (EPSG:26191) vers WGS84 (EPSG:4326)
-    ST_Transform(
-      ST_GeomFromText(
-        'POLYGON((
-          409201.18 369451.53,
-          409639.39 368996.57,
-          409763.12 368701.53,
-          409854.56 368701.50,
-          409874.98 368535.76,
-          409901.57 368332.92,
-          409954.02 368056.56,
-          409957.84 368038.85,
-          410025.04 367870.11,
-          410201.81 367573.04,
-          410291.56 367448.47,
-          410374.16 367349.62,
-          410511.24 367195.09,
-          410533.95 367167.98,
-          409747.77 367450.59,
-          409177.19 367596.60,
-          409169.80 367713.76,
-          409079.41 367761.79,
-          409093.04 367817.50,
-          409207.30 368014.74,
-          409272.68 368149.40,
-          409154.81 368156.65,
-          409177.97 368416.89,
-          409297.11 368471.41,
-          409302.81 368473.53,
-          409295.06 368673.32,
-          409240.68 368810.94,
-          409439.13 368804.35,
-          409201.18 369451.53
-        ))',
-        26191
-      ),
-      4326
-    )
-  )
-  RETURNING id, geometry
-)
-
-INSERT INTO zones (
-  id, zone_type_id, is_available,
-  region_id, total_area, total_parcels, available_parcels, color, centroid
-)
-SELECT
-  ins.id,
-  1, -- zone privée
-  TRUE,
-  4, -- Rabat-Salé-Kénitra
-  ST_Area(ins.geometry::geography)/10000.0, 10, 7, '#123456',
-  ST_Centroid(ins.geometry)
-FROM ins;
-
--- Ajouter une zone de démonstration (comme dans votre fichier original)
-WITH ins AS (
-  INSERT INTO spatial_entities (entity_type, name, description, geometry)
-  VALUES (
-    'zone', 'ZAINA', 'Zone générée automatiquement pour les tests',
-    -- Conversion des coordonnées Lambert Nord Maroc (EPSG:26191) vers WGS84 (EPSG:4326)
-    ST_Transform(
-      ST_GeomFromText(
-        'POLYGON((
-          356080.37 362485.7,
-          356300.3 362622.77,
-          356362.67 362678.46,
-          356382.85 362654.5,
-          356488.42 362741.75,
-          356414.57 362826.04,
-          356652.88 362572.56,
-          356402.7 362384.79,
-          356205.35 362159.02,
-          356069.83 362316.55,
-          356056.8 362334.26,
-          356051.06 362334.96,
-          355943.48 362290.95,
-          355924.29 362492.89,
-          355931.72 362495.13,
-          355940.2 362390.88,
-          355947.7 362297.1,
-          356063.49 362345.51,
-          356074.42 362421.96,
-          356082.49 362454.89,
-          356080.37 362485.7
-        ))',
-        26191
-      ),
-      4326
-    )
-  )
-  RETURNING id, geometry
-)
-
-INSERT INTO zones (
-  id, zone_type_id, is_available,
-  region_id, total_area, total_parcels, available_parcels, color, centroid
-)
-SELECT
-  ins.id,
-  1, -- zone privée
-  TRUE,
-  4, -- Rabat-Salé-Kénitra
-  ST_Area(ins.geometry::geography)/10000.0, 10, 7, '#123456',
-  ST_Centroid(ins.geometry)
-FROM ins;
-
-INSERT INTO zones (
-  id, zone_type_id, is_available,
-  region_id, total_area, total_parcels, available_parcels, color, centroid
-)
-SELECT
-  ins.id,
-  1, -- zone privée
-  TRUE,
-  4, -- Rabat-Salé-Kénitra
-  ST_Area(ins.geometry::geography)/10000.0, 10, 7, '#123456',
-  ST_Centroid(ins.geometry)
-FROM ins;
-
--- Ajouter une zone de démonstration (comme dans votre fichier original)
-WITH ins AS (
-  INSERT INTO spatial_entities (entity_type, name, description, geometry)
-  VALUES (
-    'zone', 'OTTAWA', 'Zone générée automatiquement pour les tests',
-    -- Conversion des coordonnées Lambert Nord Maroc (EPSG:26191) vers WGS84 (EPSG:4326)
-    ST_Transform(
-      ST_GeomFromText(
-        'POLYGON((
-          351900.19 363533.59,
-          351989.68 363531.3,
-          351988.73 363461.25,
-          352188.64 363456.87,
-          352187.55 363381.01,
-          352384.73 363378.29,
-          352381.99 363232.45,
-          352287.38 363208.55,
-          352241.53 363105.9,
-          352244.52 363034.29,
-          352303.18 362994.99,
-          352241.33 362969.6,
-          352074.35 362901.55,
-          351963.88 362855.44,
-          351980.16 362887.19,
-          352030.09 363036.02,
-          352045.39 363088.39,
-          351909.06 363178.15,
-          351931.83 363461.12,
-          351900.19 363533.59
-        ))',
-        26191
-      ),
-      4326
-    )
-  )
-  RETURNING id, geometry
-)
-
-INSERT INTO zones (
-  id, zone_type_id, is_available,
-  region_id, total_area, total_parcels, available_parcels, color, centroid
-)
-SELECT
-  ins.id,
-  1, -- zone privée
-  TRUE,
-  4, -- Rabat-Salé-Kénitra
-  ST_Area(ins.geometry::geography)/10000.0, 10, 7, '#123456',
-  ST_Centroid(ins.geometry)
-FROM ins;
-
--- Message de fin
-DO $$
-BEGIN
-  RAISE NOTICE '✅ Database initialization completed successfully!';
 END $$;
 
+-- Demo users
+INSERT INTO users (
+  id, email, password, name, company, phone, role,
+  "createdAt", "updatedAt"
+) VALUES
+  ('user-admin',   'admin@zonespro.ma',   '$2b$10$VQl88VBIZ6aR46F7Ju2sgO0LH8oTFbm0Mb8ayY1KeuU261EfwEnZS', 'Administrateur ZonesPro', 'ZonesPro Management', '+212 5 37 57 20 00', 'ADMIN',   NOW(), NOW()),
+  ('user-manager', 'manager@zonespro.ma', '$2b$10$VQl88VBIZ6aR46F7Ju2sgO0LH8oTFbm0Mb8ayY1KeuU261EfwEnZS', 'Manager Commercial',       'ZonesPro Management', '+212 5 37 57 20 01', 'MANAGER', NOW(), NOW()),
+  ('user-demo',    'demo@entreprise.ma',  '$2b$10$VQl88VBIZ6aR46F7Ju2sgO0LH8oTFbm0Mb8ayY1KeuU261EfwEnZS', 'Utilisateur Démo',         'Entreprise Démo SA',   '+212 6 12 34 56 78', 'USER',    NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+-- Country and regions
+INSERT INTO countries (id, name, code, "createdAt", "updatedAt") VALUES
+  ('country-ma', 'Maroc', 'MA', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO regions (id, name, code, "countryId", "createdAt", "updatedAt") VALUES
+  ('region-cas', 'Casablanca-Settat', 'CAS', 'country-ma', NOW(), NOW()),
+  ('region-rab', 'Rabat-Salé-Kénitra', 'RAB', 'country-ma', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+-- Zone types
+INSERT INTO zone_types (id, name) VALUES
+  ('zt-private', 'privée'),
+  ('zt-public',  'public')
+ON CONFLICT (id) DO NOTHING;
+
+-- Activities
+INSERT INTO activities (id, name, description, icon, "createdAt", "updatedAt") VALUES
+  ('act-auto', 'Automobile', 'Industrie automobile', '🚗', NOW(), NOW()),
+  ('act-log',  'Logistique', 'Stockage et distribution', '📦', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+-- Amenities
+INSERT INTO amenities (id, name, description, icon, category, "createdAt", "updatedAt") VALUES
+  ('amn-electricity', 'Électricité', 'Alimentation électrique', '⚡', 'Infrastructure', NOW(), NOW()),
+  ('amn-water',       'Eau potable', 'Réseau d''eau',             '💧', 'Infrastructure', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+-- Demo zone
+INSERT INTO zones (
+  id, name, description, address, "totalArea", price, status,
+  latitude, longitude, "lambertX", "lambertY",
+  "zoneTypeId", "regionId", "createdAt", "updatedAt"
+) VALUES (
+  'zone-demo',
+  'Zone Industrielle Demo',
+  'Zone de démonstration',
+  'Route Demo',
+  150000,
+  2500,
+  'AVAILABLE',
+  33.6169,
+  -7.6149,
+  423456.78,
+  372890.12,
+  'zt-private',
+  'region-cas',
+  NOW(), NOW()
+) ON CONFLICT (id) DO NOTHING;
+
+-- Parcels for the demo zone
+INSERT INTO parcels (
+  id, reference, area, price, status,
+  "isFree", "isShowroom", cos, cus,
+  latitude, longitude, "lambertX", "lambertY",
+  "zoneId", "createdAt", "updatedAt"
+) VALUES
+  ('parcel-1', 'CAS-001', 10000, 2500, 'AVAILABLE', true, false, NULL, NULL, 33.617, -7.615, 423457, 372891, 'zone-demo', NOW(), NOW()),
+  ('parcel-2', 'CAS-002', 12000, 2500, 'RESERVED', true, false, NULL, NULL, 33.618, -7.616, 423458, 372892, 'zone-demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+-- Lambert polygon vertices for the demo zone
+INSERT INTO zone_vertices ("zoneId", seq, "lambertX", "lambertY") VALUES
+  ('zone-demo', 1, 423400, 372800),
+  ('zone-demo', 2, 423600, 372800),
+  ('zone-demo', 3, 423600, 373000),
+  ('zone-demo', 4, 423400, 373000)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO parcel_vertices ("parcelId", seq, "lambertX", "lambertY") VALUES
+  ('parcel-1', 1, 423450, 372880),
+  ('parcel-1', 2, 423480, 372880),
+  ('parcel-1', 3, 423480, 372910),
+  ('parcel-1', 4, 423450, 372910),
+  ('parcel-2', 1, 423500, 372890),
+  ('parcel-2', 2, 423530, 372890),
+  ('parcel-2', 3, 423530, 372920),
+  ('parcel-2', 4, 423500, 372920)
+ON CONFLICT DO NOTHING;
+
+-- Link activities and amenities to the zone
+INSERT INTO zone_activities (id, "zoneId", "activityId") VALUES
+  ('za-1', 'zone-demo', 'act-auto'),
+  ('za-2', 'zone-demo', 'act-log')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO zone_amenities (id, "zoneId", "amenityId") VALUES
+  ('zam-1', 'zone-demo', 'amn-electricity'),
+  ('zam-2', 'zone-demo', 'amn-water')
+ON CONFLICT (id) DO NOTHING;
+
+-- Additional demo zones generated from Lambert polygons
+-- Zone PIAJ
+INSERT INTO zones (
+  id, name, description, "totalArea", price, status,
+  latitude, longitude, "lambertX", "lambertY",
+  "zoneTypeId", "regionId", "createdAt", "updatedAt"
+) VALUES (
+  'zone-piaj', 'PIAJ', 'Zone générée automatiquement pour les tests',
+  1201325.73, 0, 'AVAILABLE',
+  33.907861, -6.375832,
+  409631.94, 368109.73,
+  'zt-private', 'region-rab', NOW(), NOW()
+) ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO zone_vertices ("zoneId", seq, "lambertX", "lambertY") VALUES
+  ('zone-piaj', 1, 409201.18, 369451.53),
+  ('zone-piaj', 2, 409639.39, 368996.57),
+  ('zone-piaj', 3, 409763.12, 368701.53),
+  ('zone-piaj', 4, 409854.56, 368701.5),
+  ('zone-piaj', 5, 409874.98, 368535.76),
+  ('zone-piaj', 6, 409901.57, 368332.92),
+  ('zone-piaj', 7, 409954.02, 368056.56),
+  ('zone-piaj', 8, 409957.84, 368038.85),
+  ('zone-piaj', 9, 410025.04, 367870.11),
+  ('zone-piaj', 10, 410201.81, 367573.04),
+  ('zone-piaj', 11, 410291.56, 367448.47),
+  ('zone-piaj', 12, 410374.16, 367349.62),
+  ('zone-piaj', 13, 410511.24, 367195.09),
+  ('zone-piaj', 14, 410533.95, 367167.98),
+  ('zone-piaj', 15, 409747.77, 367450.59),
+  ('zone-piaj', 16, 409177.19, 367596.6),
+  ('zone-piaj', 17, 409169.8, 367713.76),
+  ('zone-piaj', 18, 409079.41, 367761.79),
+  ('zone-piaj', 19, 409093.04, 367817.5),
+  ('zone-piaj', 20, 409207.3, 368014.74),
+  ('zone-piaj', 21, 409272.68, 368149.4),
+  ('zone-piaj', 22, 409154.81, 368156.65),
+  ('zone-piaj', 23, 409177.97, 368416.89),
+  ('zone-piaj', 24, 409297.11, 368471.41),
+  ('zone-piaj', 25, 409302.81, 368473.53),
+  ('zone-piaj', 26, 409295.06, 368673.32),
+  ('zone-piaj', 27, 409240.68, 368810.94),
+  ('zone-piaj', 28, 409439.13, 368804.35),
+  ('zone-piaj', 29, 409201.18, 369451.53)
+ON CONFLICT DO NOTHING;
+
+-- Zone ZAINA
+INSERT INTO zones (
+  id, name, description, "totalArea", price, status,
+  latitude, longitude, "lambertX", "lambertY",
+  "zoneTypeId", "regionId", "createdAt", "updatedAt"
+) VALUES (
+  'zone-zaina', 'ZAINA', 'Zone générée automatiquement pour les tests',
+  159338.90, 0, 'AVAILABLE',
+  33.851166, -6.951490,
+  356319.60, 362468.27,
+  'zt-private', 'region-rab', NOW(), NOW()
+) ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO zone_vertices ("zoneId", seq, "lambertX", "lambertY") VALUES
+  ('zone-zaina', 1, 356080.37, 362485.7),
+  ('zone-zaina', 2, 356300.3, 362622.77),
+  ('zone-zaina', 3, 356362.67, 362678.46),
+  ('zone-zaina', 4, 356382.85, 362654.5),
+  ('zone-zaina', 5, 356488.42, 362741.75),
+  ('zone-zaina', 6, 356414.57, 362826.04),
+  ('zone-zaina', 7, 356652.88, 362572.56),
+  ('zone-zaina', 8, 356402.7, 362384.79),
+  ('zone-zaina', 9, 356205.35, 362159.02),
+  ('zone-zaina', 10, 356069.83, 362316.55),
+  ('zone-zaina', 11, 356056.8, 362334.26),
+  ('zone-zaina', 12, 356051.06, 362334.96),
+  ('zone-zaina', 13, 355943.48, 362290.95),
+  ('zone-zaina', 14, 355924.29, 362492.89),
+  ('zone-zaina', 15, 355931.72, 362495.13),
+  ('zone-zaina', 16, 355940.2, 362390.88),
+  ('zone-zaina', 17, 355947.7, 362297.1),
+  ('zone-zaina', 18, 356063.49, 362345.51),
+  ('zone-zaina', 19, 356074.42, 362421.96),
+  ('zone-zaina', 20, 356082.49, 362454.89),
+  ('zone-zaina', 21, 356080.37, 362485.7)
+ON CONFLICT DO NOTHING;
+
+-- Zone OTTAWA
+INSERT INTO zones (
+  id, name, description, "totalArea", price, status,
+  latitude, longitude, "lambertX", "lambertY",
+  "zoneTypeId", "regionId", "createdAt", "updatedAt"
+) VALUES (
+  'zone-ottawa', 'OTTAWA', 'Zone générée automatiquement pour les tests',
+  181100.01, 0, 'AVAILABLE',
+  33.857374, -6.997026,
+  352117.78, 363220.00,
+  'zt-private', 'region-rab', NOW(), NOW()
+) ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO zone_vertices ("zoneId", seq, "lambertX", "lambertY") VALUES
+  ('zone-ottawa', 1, 351900.19, 363533.59),
+  ('zone-ottawa', 2, 351989.68, 363531.3),
+  ('zone-ottawa', 3, 351988.73, 363461.25),
+  ('zone-ottawa', 4, 352188.64, 363456.87),
+  ('zone-ottawa', 5, 352187.55, 363381.01),
+  ('zone-ottawa', 6, 352384.73, 363378.29),
+  ('zone-ottawa', 7, 352381.99, 363232.45),
+  ('zone-ottawa', 8, 352287.38, 363208.55),
+  ('zone-ottawa', 9, 352241.53, 363105.9),
+  ('zone-ottawa', 10, 352244.52, 363034.29),
+  ('zone-ottawa', 11, 352303.18, 362994.99),
+  ('zone-ottawa', 12, 352241.33, 362969.6),
+  ('zone-ottawa', 13, 352074.35, 362901.55),
+  ('zone-ottawa', 14, 351963.88, 362855.44),
+  ('zone-ottawa', 15, 351980.16, 362887.19),
+  ('zone-ottawa', 16, 352030.09, 363036.02),
+  ('zone-ottawa', 17, 352045.39, 363088.39),
+  ('zone-ottawa', 18, 351909.06, 363178.15),
+  ('zone-ottawa', 19, 351931.83, 363461.12),
+  ('zone-ottawa', 20, 351900.19, 363533.59)
+ON CONFLICT DO NOTHING;
+
+-- Simple appointment example
+INSERT INTO appointments (
+  id, "contactName", "contactEmail", "contactPhone", "companyName", message,
+  "requestedDate", status, "parcelId", "userId", "createdAt", "updatedAt"
+) VALUES (
+  'appt-1',
+  'Ahmed Benali', 'a.benali@entreprise.ma', '+212 6 12 34 56 78',
+  'Industries Benali', 'Intéressé par une parcelle',
+  '2024-02-15T10:00:00Z', 'PENDING', 'parcel-1', 'user-demo', NOW(), NOW()
+) ON CONFLICT (id) DO NOTHING;
+
+DO $$ BEGIN
+  RAISE NOTICE '✅ Database initialization completed successfully!';
+END $$;

--- a/Back-End/middleware.ts
+++ b/Back-End/middleware.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const headers = new Headers({
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization'
+  })
+
+  if (request.method === 'OPTIONS') {
+    return new NextResponse(null, { status: 204, headers })
+  }
+
+  const response = NextResponse.next()
+  headers.forEach((value, key) => response.headers.set(key, value))
+  return response
+}
+
+export const config = {
+  matcher: '/api/:path*'
+}

--- a/Back-End/prisma/schema.prisma
+++ b/Back-End/prisma/schema.prisma
@@ -102,16 +102,16 @@ model Zone {
   parcels    Parcel[]
   activities ZoneActivity[]
   amenities  ZoneAmenity[]
+  vertices   ZoneVertex[]
 
   @@map("zones")
 }
 
 enum ZoneStatus {
   AVAILABLE
-  PARTIALLY_OCCUPIED
-  FULLY_OCCUPIED
-  UNDER_DEVELOPMENT
   RESERVED
+  OCCUPIED
+  SHOWROOM
 }
 
 // Modèle Parcel (Parcelle)
@@ -121,6 +121,10 @@ model Parcel {
   area        Float // en m²
   price       Float? // prix total ou par m²
   status      ParcelStatus @default(AVAILABLE)
+  isFree      Boolean      @default(true)
+  isShowroom  Boolean      @default(false)
+  cos         Float?
+  cus         Float?
 
   // Coordonnées géographiques
   latitude    Float?
@@ -138,6 +142,7 @@ model Parcel {
   zone         Zone          @relation(fields: [zoneId], references: [id], onDelete: Cascade)
   appointments Appointment[]
   amenities    ParcelAmenity[]
+  vertices     ParcelVertex[]
 
   @@map("parcels")
 }
@@ -268,4 +273,30 @@ model ActivityLog {
   user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
 
   @@map("activity_logs")
+}
+
+model ZoneVertex {
+  id       Int    @id @default(autoincrement())
+  zoneId   String
+  seq      Int
+  lambertX Float
+  lambertY Float
+
+  zone Zone @relation(fields: [zoneId], references: [id], onDelete: Cascade)
+
+  @@unique([zoneId, seq])
+  @@map("zone_vertices")
+}
+
+model ParcelVertex {
+  id       Int    @id @default(autoincrement())
+  parcelId String
+  seq      Int
+  lambertX Float
+  lambertY Float
+
+  parcel Parcel @relation(fields: [parcelId], references: [id], onDelete: Cascade)
+
+  @@unique([parcelId, seq])
+  @@map("parcel_vertices")
 }

--- a/Back-End/prisma/seed.ts
+++ b/Back-End/prisma/seed.ts
@@ -233,7 +233,7 @@ async function main() {
         address: 'Zone Industrielle, Mohammedia',
         totalArea: 200000, // 20 hectares
         price: 1800,
-        status: ZoneStatus.PARTIALLY_OCCUPIED,
+        status: ZoneStatus.OCCUPIED,
         latitude: 33.6864,
         longitude: -7.3737,
         lambertX: 445123.45,
@@ -265,7 +265,7 @@ async function main() {
         address: 'Technopolis, Salé',
         totalArea: 80000, // 8 hectares
         price: 4000,
-        status: ZoneStatus.UNDER_DEVELOPMENT,
+        status: ZoneStatus.RESERVED,
         latitude: 34.0209,
         longitude: -6.8416,
         lambertX: 467890.23,
@@ -289,6 +289,10 @@ async function main() {
         area: 5000 + Math.random() * 10000, // 5000-15000 m²
         price: 2500,
         status: i <= 8 ? ParcelStatus.AVAILABLE : ParcelStatus.RESERVED,
+        isFree: true,
+        isShowroom: false,
+        cos: null,
+        cus: null,
         latitude: zones[0].latitude! + (Math.random() - 0.5) * 0.01,
         longitude: zones[0].longitude! + (Math.random() - 0.5) * 0.01,
         zoneId: zones[0].id,
@@ -305,6 +309,10 @@ async function main() {
         area: 8000 + Math.random() * 12000, // 8000-20000 m²
         price: 1800,
         status: i <= 10 ? ParcelStatus.AVAILABLE : ParcelStatus.OCCUPIED,
+        isFree: true,
+        isShowroom: false,
+        cos: null,
+        cus: null,
         latitude: zones[1].latitude! + (Math.random() - 0.5) * 0.01,
         longitude: zones[1].longitude! + (Math.random() - 0.5) * 0.01,
         zoneId: zones[1].id,

--- a/Back-End/scripts/run_initdb.sh
+++ b/Back-End/scripts/run_initdb.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Populate the PostgreSQL database using the initDB.sql file
+set -euo pipefail
+
+# Configuration via environment variables with sensible defaults
+DB_HOST=${DB_HOST:-localhost}
+DB_PORT=${DB_PORT:-5432}
+DB_USER=${DB_USER:-postgres}
+DB_NAME=${DB_NAME:-industria}
+SQL_FILE="${SQL_FILE:-$(dirname "$0")/../db/init/initDB.sql}"
+
+DOCKER_SERVICE=${DOCKER_SERVICE:-db}
+
+run_psql() {
+  if [ -z "${PGPASSWORD:-}" ]; then
+    echo "Please set the PGPASSWORD environment variable with your database password." >&2
+    exit 1
+  fi
+  echo "Running ${SQL_FILE} on ${DB_HOST}:${DB_PORT}/${DB_NAME} ..."
+  psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -f "$SQL_FILE"
+  echo "Database initialized."
+}
+
+run_psql_docker() {
+  local compose
+  if command -v docker-compose >/dev/null; then
+    compose="docker-compose"
+  else
+    compose="docker compose"
+  fi
+
+  if ! $compose ps -q "$DOCKER_SERVICE" >/dev/null; then
+    echo "Docker service '$DOCKER_SERVICE' is not running." >&2
+    exit 1
+  fi
+
+  echo "Running ${SQL_FILE} inside Docker service '$DOCKER_SERVICE' ..."
+  $compose exec -T -e PGPASSWORD="${PGPASSWORD:-postgres}" "$DOCKER_SERVICE" \
+    psql -U "$DB_USER" -d "$DB_NAME" -f "/docker-entrypoint-initdb.d/$(basename "$SQL_FILE")"
+  echo "Database initialized in container."
+}
+
+if command -v psql >/dev/null; then
+  run_psql
+else
+  echo "psql not found locally, attempting to use Docker..."
+  if command -v docker >/dev/null; then
+    run_psql_docker
+  else
+    echo "Neither psql nor Docker is available." >&2
+    exit 1
+  fi
+fi
+

--- a/Back-End/src/app/api/activities/[id]/route.ts
+++ b/Back-End/src/app/api/activities/[id]/route.ts
@@ -1,26 +1,31 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const item = await prisma.activity.findUnique({ where: { id: params.id } });
-  if (!item) return new Response('Not Found', { status: 404 });
-  return Response.json(item);
+  if (!item) return applyCors(new Response('Not Found', { status: 404 }));
+  return applyCors(Response.json(item));
 }
 
 export async function PUT(req: Request, { params }: { params: { id: string } }) {
   try {
     const data = await req.json();
     const item = await prisma.activity.update({ where: { id: params.id }, data });
-    return Response.json(item);
+    return applyCors(Response.json(item));
   } catch {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
 }
 
 export async function DELETE(req: Request, { params }: { params: { id: string } }) {
   try {
     await prisma.activity.delete({ where: { id: params.id } });
-    return new Response(null, { status: 204 });
+    return applyCors(new Response(null, { status: 204 }));
   } catch {
-    return new Response('Not Found', { status: 404 });
+    return applyCors(new Response('Not Found', { status: 404 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/activities/route.ts
+++ b/Back-End/src/app/api/activities/route.ts
@@ -1,16 +1,21 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 
 export async function GET() {
   const items = await prisma.activity.findMany();
-  return Response.json(items);
+  return applyCors(Response.json(items));
 }
 
 export async function POST(req: Request) {
   try {
     const data = await req.json();
     const item = await prisma.activity.create({ data });
-    return Response.json(item, { status: 201 });
+    return applyCors(Response.json(item, { status: 201 }));
   } catch {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/admin/stats/route.ts
+++ b/Back-End/src/app/api/admin/stats/route.ts
@@ -1,3 +1,4 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from '@/lib/prisma';
 
 export async function GET() {
@@ -23,13 +24,19 @@ export async function GET() {
     })
   ]);
 
-  return Response.json({
-    totalUsers,
-    totalZones,
-    totalParcels,
-    totalAppointments,
-    pendingAppointments,
-    availableParcels,
-    recentActivities
-  });
+  return applyCors(
+    Response.json({
+      totalUsers,
+      totalZones,
+      totalParcels,
+      totalAppointments,
+      pendingAppointments,
+      availableParcels,
+      recentActivities
+    })
+  );
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/amenities/[id]/route.ts
+++ b/Back-End/src/app/api/amenities/[id]/route.ts
@@ -1,26 +1,31 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const item = await prisma.amenity.findUnique({ where: { id: params.id } });
-  if (!item) return new Response('Not Found', { status: 404 });
-  return Response.json(item);
+  if (!item) return applyCors(new Response('Not Found', { status: 404 }));
+  return applyCors(Response.json(item));
 }
 
 export async function PUT(req: Request, { params }: { params: { id: string } }) {
   try {
     const data = await req.json();
     const item = await prisma.amenity.update({ where: { id: params.id }, data });
-    return Response.json(item);
+    return applyCors(Response.json(item));
   } catch {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
 }
 
 export async function DELETE(req: Request, { params }: { params: { id: string } }) {
   try {
     await prisma.amenity.delete({ where: { id: params.id } });
-    return new Response(null, { status: 204 });
+    return applyCors(new Response(null, { status: 204 }));
   } catch {
-    return new Response('Not Found', { status: 404 });
+    return applyCors(new Response('Not Found', { status: 404 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/amenities/route.ts
+++ b/Back-End/src/app/api/amenities/route.ts
@@ -1,16 +1,21 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 
 export async function GET() {
   const items = await prisma.amenity.findMany();
-  return Response.json(items);
+  return applyCors(Response.json(items));
 }
 
 export async function POST(req: Request) {
   try {
     const data = await req.json();
     const item = await prisma.amenity.create({ data });
-    return Response.json(item, { status: 201 });
+    return applyCors(Response.json(item, { status: 201 }));
   } catch {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/appointments/[id]/route.ts
+++ b/Back-End/src/app/api/appointments/[id]/route.ts
@@ -1,26 +1,31 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const item = await prisma.appointment.findUnique({ where: { id: params.id } });
-  if (!item) return new Response('Not Found', { status: 404 });
-  return Response.json(item);
+  if (!item) return applyCors(new Response('Not Found', { status: 404 }));
+  return applyCors(Response.json(item));
 }
 
 export async function PUT(req: Request, { params }: { params: { id: string } }) {
   try {
     const data = await req.json();
     const item = await prisma.appointment.update({ where: { id: params.id }, data });
-    return Response.json(item);
+    return applyCors(Response.json(item));
   } catch {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
 }
 
 export async function DELETE(req: Request, { params }: { params: { id: string } }) {
   try {
     await prisma.appointment.delete({ where: { id: params.id } });
-    return new Response(null, { status: 204 });
+    return applyCors(new Response(null, { status: 204 }));
   } catch {
-    return new Response('Not Found', { status: 404 });
+    return applyCors(new Response('Not Found', { status: 404 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/appointments/route.ts
+++ b/Back-End/src/app/api/appointments/route.ts
@@ -1,16 +1,27 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 
 export async function GET() {
   const items = await prisma.appointment.findMany();
-  return Response.json(items);
+  return applyCors(Response.json(items));
 }
 
 export async function POST(req: Request) {
   try {
     const data = await req.json();
+    if (data.parcelId) {
+      const parcel = await prisma.parcel.findUnique({ where: { id: data.parcelId } });
+      if (!parcel || parcel.status !== 'AVAILABLE' || !parcel.isFree) {
+        return applyCors(new Response('Parcel not available', { status: 400 }));
+      }
+    }
     const item = await prisma.appointment.create({ data });
-    return Response.json(item, { status: 201 });
+    return applyCors(Response.json(item, { status: 201 }));
   } catch {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/auth/login/route.ts
+++ b/Back-End/src/app/api/auth/login/route.ts
@@ -1,3 +1,4 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 // Back-End/src/app/api/auth/login/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
@@ -8,9 +9,11 @@ export async function POST(request: NextRequest) {
     const { email, password } = await request.json();
 
     if (!email || !password) {
-      return NextResponse.json(
-        { message: 'Email et mot de passe requis' },
-        { status: 400 }
+      return applyCors(
+        NextResponse.json(
+          { message: 'Email et mot de passe requis' },
+          { status: 400 }
+        )
       );
     }
 
@@ -19,18 +22,22 @@ export async function POST(request: NextRequest) {
     });
 
     if (!user || !user.isActive) {
-      return NextResponse.json(
-        { message: 'Identifiants invalides' },
-        { status: 401 }
+      return applyCors(
+        NextResponse.json(
+          { message: 'Identifiants invalides' },
+          { status: 401 }
+        )
       );
     }
 
     const isValidPassword = await bcrypt.compare(password, user.password);
 
     if (!isValidPassword) {
-      return NextResponse.json(
-        { message: 'Identifiants invalides' },
-        { status: 401 }
+      return applyCors(
+        NextResponse.json(
+          { message: 'Identifiants invalides' },
+          { status: 401 }
+        )
       );
     }
 
@@ -45,21 +52,28 @@ export async function POST(request: NextRequest) {
       }
     });
 
-    return NextResponse.json({
-      user: {
-        id: user.id,
-        email: user.email,
-        name: user.name,
-        company: user.company,
-        role: user.role,
-      }
-    });
+    return applyCors(
+      NextResponse.json({
+        user: {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          company: user.company,
+          role: user.role,
+        }
+      })
+    );
 
   } catch (error) {
     console.error('Erreur de connexion:', error);
-    return NextResponse.json(
-      { message: 'Erreur interne du serveur' },
-      { status: 500 }
+    return applyCors(
+      NextResponse.json(
+        { message: 'Erreur interne du serveur' },
+        { status: 500 }
+      )
     );
   }
+}
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/countries/[id]/route.ts
+++ b/Back-End/src/app/api/countries/[id]/route.ts
@@ -1,26 +1,31 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const item = await prisma.country.findUnique({ where: { id: params.id } });
-  if (!item) return new Response('Not Found', { status: 404 });
-  return Response.json(item);
+  if (!item) return applyCors(new Response('Not Found', { status: 404 }));
+  return applyCors(Response.json(item));
 }
 
 export async function PUT(req: Request, { params }: { params: { id: string } }) {
   try {
     const data = await req.json();
     const item = await prisma.country.update({ where: { id: params.id }, data });
-    return Response.json(item);
+    return applyCors(Response.json(item));
   } catch {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
 }
 
 export async function DELETE(req: Request, { params }: { params: { id: string } }) {
   try {
     await prisma.country.delete({ where: { id: params.id } });
-    return new Response(null, { status: 204 });
+    return applyCors(new Response(null, { status: 204 }));
   } catch {
-    return new Response('Not Found', { status: 404 });
+    return applyCors(new Response('Not Found', { status: 404 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/countries/route.ts
+++ b/Back-End/src/app/api/countries/route.ts
@@ -1,16 +1,21 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 
 export async function GET() {
   const items = await prisma.country.findMany();
-  return Response.json(items);
+  return applyCors(Response.json(items));
 }
 
 export async function POST(req: Request) {
   try {
     const data = await req.json();
     const item = await prisma.country.create({ data });
-    return Response.json(item, { status: 201 });
+    return applyCors(Response.json(item, { status: 201 }));
   } catch {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/map/parcels/route.ts
+++ b/Back-End/src/app/api/map/parcels/route.ts
@@ -1,3 +1,4 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 
 export async function GET() {
@@ -13,5 +14,9 @@ export async function GET() {
       properties: { id: p.id, reference: p.reference, zoneId: p.zoneId }
     }));
 
-  return Response.json({ type: "FeatureCollection", features });
+  return applyCors(Response.json({ type: "FeatureCollection", features }));
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/parcels/[id]/route.ts
+++ b/Back-End/src/app/api/parcels/[id]/route.ts
@@ -1,26 +1,45 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
-  const item = await prisma.parcel.findUnique({ where: { id: params.id } });
-  if (!item) return new Response('Not Found', { status: 404 });
-  return Response.json(item);
+  const item = await prisma.parcel.findUnique({
+    where: { id: params.id },
+    include: { vertices: true },
+  });
+  if (!item) return applyCors(new Response('Not Found', { status: 404 }));
+  return applyCors(Response.json(item));
 }
 
 export async function PUT(req: Request, { params }: { params: { id: string } }) {
   try {
     const data = await req.json();
-    const item = await prisma.parcel.update({ where: { id: params.id }, data });
-    return Response.json(item);
+    const { vertices, ...parcelData } = data;
+    await prisma.parcel.update({ where: { id: params.id }, data: parcelData });
+    if (Array.isArray(vertices)) {
+      await prisma.parcelVertex.deleteMany({ where: { parcelId: params.id } });
+      await prisma.parcelVertex.createMany({
+        data: vertices.map((v: any) => ({ ...v, parcelId: params.id })),
+      });
+    }
+    const item = await prisma.parcel.findUnique({
+      where: { id: params.id },
+      include: { vertices: true },
+    });
+    return applyCors(Response.json(item));
   } catch {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
 }
 
 export async function DELETE(req: Request, { params }: { params: { id: string } }) {
   try {
     await prisma.parcel.delete({ where: { id: params.id } });
-    return new Response(null, { status: 204 });
+    return applyCors(new Response(null, { status: 204 }));
   } catch {
-    return new Response('Not Found', { status: 404 });
+    return applyCors(new Response('Not Found', { status: 404 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/parcels/route.ts
+++ b/Back-End/src/app/api/parcels/route.ts
@@ -1,16 +1,30 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 
 export async function GET() {
-  const items = await prisma.parcel.findMany();
-  return Response.json(items);
+  const items = await prisma.parcel.findMany({ include: { vertices: true } });
+  return applyCors(Response.json(items));
 }
 
 export async function POST(req: Request) {
   try {
     const data = await req.json();
-    const item = await prisma.parcel.create({ data });
-    return Response.json(item, { status: 201 });
+    const { vertices, ...parcelData } = data;
+    const item = await prisma.parcel.create({
+      data: {
+        ...parcelData,
+        vertices: vertices && Array.isArray(vertices)
+          ? { createMany: { data: vertices } }
+          : undefined,
+      },
+      include: { vertices: true },
+    });
+    return applyCors(Response.json(item, { status: 201 }));
   } catch {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/regions/[id]/route.ts
+++ b/Back-End/src/app/api/regions/[id]/route.ts
@@ -1,26 +1,31 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const item = await prisma.region.findUnique({ where: { id: params.id } });
-  if (!item) return new Response('Not Found', { status: 404 });
-  return Response.json(item);
+  if (!item) return applyCors(new Response('Not Found', { status: 404 }));
+  return applyCors(Response.json(item));
 }
 
 export async function PUT(req: Request, { params }: { params: { id: string } }) {
   try {
     const data = await req.json();
     const item = await prisma.region.update({ where: { id: params.id }, data });
-    return Response.json(item);
+    return applyCors(Response.json(item));
   } catch {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
 }
 
 export async function DELETE(req: Request, { params }: { params: { id: string } }) {
   try {
     await prisma.region.delete({ where: { id: params.id } });
-    return new Response(null, { status: 204 });
+    return applyCors(new Response(null, { status: 204 }));
   } catch {
-    return new Response('Not Found', { status: 404 });
+    return applyCors(new Response('Not Found', { status: 404 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/regions/route.ts
+++ b/Back-End/src/app/api/regions/route.ts
@@ -1,16 +1,21 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 
 export async function GET() {
   const items = await prisma.region.findMany();
-  return Response.json(items);
+  return applyCors(Response.json(items));
 }
 
 export async function POST(req: Request) {
   try {
     const data = await req.json();
     const item = await prisma.region.create({ data });
-    return Response.json(item, { status: 201 });
+    return applyCors(Response.json(item, { status: 201 }));
   } catch {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/users/[id]/route.ts
+++ b/Back-End/src/app/api/users/[id]/route.ts
@@ -1,10 +1,11 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 import bcrypt from 'bcryptjs';
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const item = await prisma.user.findUnique({ where: { id: params.id }, select: { id: true, email: true, name: true, role: true, isActive: true } });
-  if (!item) return new Response('Not Found', { status: 404 });
-  return Response.json(item);
+  if (!item) return applyCors(new Response('Not Found', { status: 404 }));
+  return applyCors(Response.json(item));
 }
 
 export async function PUT(req: Request, { params }: { params: { id: string } }) {
@@ -14,17 +15,21 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
       data.password = await bcrypt.hash(data.password, 10);
     }
     const item = await prisma.user.update({ where: { id: params.id }, data });
-    return Response.json({ id: item.id, email: item.email, name: item.name, role: item.role, isActive: item.isActive });
+    return applyCors(Response.json({ id: item.id, email: item.email, name: item.name, role: item.role, isActive: item.isActive }));
   } catch {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
 }
 
 export async function DELETE(req: Request, { params }: { params: { id: string } }) {
   try {
     await prisma.user.delete({ where: { id: params.id } });
-    return new Response(null, { status: 204 });
+    return applyCors(new Response(null, { status: 204 }));
   } catch {
-    return new Response('Not Found', { status: 404 });
+    return applyCors(new Response('Not Found', { status: 404 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/users/route.ts
+++ b/Back-End/src/app/api/users/route.ts
@@ -1,9 +1,10 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 import bcrypt from 'bcryptjs';
 
 export async function GET() {
   const items = await prisma.user.findMany({ select: { id: true, email: true, name: true, role: true, isActive: true } });
-  return Response.json(items);
+  return applyCors(Response.json(items));
 }
 
 export async function POST(req: Request) {
@@ -13,8 +14,12 @@ export async function POST(req: Request) {
       data.password = await bcrypt.hash(data.password, 10);
     }
     const item = await prisma.user.create({ data });
-    return Response.json({ id: item.id, email: item.email, name: item.name, role: item.role, isActive: item.isActive }, { status: 201 });
+    return applyCors(Response.json({ id: item.id, email: item.email, name: item.name, role: item.role, isActive: item.isActive }, { status: 201 }));
   } catch {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/zone-types/[id]/route.ts
+++ b/Back-End/src/app/api/zone-types/[id]/route.ts
@@ -1,26 +1,31 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const item = await prisma.zoneType.findUnique({ where: { id: params.id } });
-  if (!item) return new Response('Not Found', { status: 404 });
-  return Response.json(item);
+  if (!item) return applyCors(new Response('Not Found', { status: 404 }));
+  return applyCors(Response.json(item));
 }
 
 export async function PUT(req: Request, { params }: { params: { id: string } }) {
   try {
     const data = await req.json();
     const item = await prisma.zoneType.update({ where: { id: params.id }, data });
-    return Response.json(item);
+    return applyCors(Response.json(item));
   } catch {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
 }
 
 export async function DELETE(req: Request, { params }: { params: { id: string } }) {
   try {
     await prisma.zoneType.delete({ where: { id: params.id } });
-    return new Response(null, { status: 204 });
+    return applyCors(new Response(null, { status: 204 }));
   } catch {
-    return new Response('Not Found', { status: 404 });
+    return applyCors(new Response('Not Found', { status: 404 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/zone-types/route.ts
+++ b/Back-End/src/app/api/zone-types/route.ts
@@ -1,16 +1,21 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
 
 export async function GET() {
   const items = await prisma.zoneType.findMany();
-  return Response.json(items);
+  return applyCors(Response.json(items));
 }
 
 export async function POST(req: Request) {
   try {
     const data = await req.json();
     const item = await prisma.zoneType.create({ data });
-    return Response.json(item, { status: 201 });
+    return applyCors(Response.json(item, { status: 201 }));
   } catch {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/zones/[id]/route.ts
+++ b/Back-End/src/app/api/zones/[id]/route.ts
@@ -1,4 +1,6 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
+import crypto from "crypto";
 
 export async function GET(
   req: Request,
@@ -7,19 +9,20 @@ export async function GET(
   const zone = await prisma.zone.findUnique({
     where: { id: params.id },
     include: {
-      parcels: true,
+      parcels: { include: { vertices: true } },
       region: true,
       zoneType: true,
       activities: { include: { activity: true } },
       amenities: { include: { amenity: true } },
+      vertices: true,
     },
   });
 
   if (!zone) {
-    return new Response("Not Found", { status: 404 });
+    return applyCors(new Response("Not Found", { status: 404 }));
   }
 
-  return Response.json(zone);
+  return applyCors(Response.json(zone));
 }
 
 export async function PUT(
@@ -28,10 +31,54 @@ export async function PUT(
 ) {
   try {
     const data = await req.json();
-    const zone = await prisma.zone.update({ where: { id: params.id }, data });
-    return Response.json(zone);
+    const { vertices, activityIds, amenityIds, ...zoneData } = data;
+
+    await prisma.zone.update({ where: { id: params.id }, data: zoneData });
+
+    if (Array.isArray(vertices)) {
+      await prisma.zoneVertex.deleteMany({ where: { zoneId: params.id } });
+      await prisma.zoneVertex.createMany({
+        data: vertices.map((v: any) => ({ ...v, zoneId: params.id })),
+      });
+    }
+
+    if (Array.isArray(activityIds)) {
+      await prisma.zoneActivity.deleteMany({ where: { zoneId: params.id } });
+      await prisma.zoneActivity.createMany({
+        data: activityIds.map((id: string) => ({
+          id: crypto.randomUUID(),
+          zoneId: params.id,
+          activityId: id,
+        })),
+      });
+    }
+
+    if (Array.isArray(amenityIds)) {
+      await prisma.zoneAmenity.deleteMany({ where: { zoneId: params.id } });
+      await prisma.zoneAmenity.createMany({
+        data: amenityIds.map((id: string) => ({
+          id: crypto.randomUUID(),
+          zoneId: params.id,
+          amenityId: id,
+        })),
+      });
+    }
+
+    const zone = await prisma.zone.findUnique({
+      where: { id: params.id },
+      include: {
+        vertices: true,
+        parcels: { include: { vertices: true } },
+        activities: { include: { activity: true } },
+        amenities: { include: { amenity: true } },
+        region: true,
+        zoneType: true,
+      },
+    });
+
+    return applyCors(Response.json(zone));
   } catch (error) {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
 }
 
@@ -41,8 +88,12 @@ export async function DELETE(
 ) {
   try {
     await prisma.zone.delete({ where: { id: params.id } });
-    return new Response(null, { status: 204 });
+    return applyCors(new Response(null, { status: 204 }));
   } catch (error) {
-    return new Response('Not Found', { status: 404 });
+    return applyCors(new Response('Not Found', { status: 404 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/app/api/zones/route.ts
+++ b/Back-End/src/app/api/zones/route.ts
@@ -1,22 +1,99 @@
+import { applyCors, corsOptions } from "@/lib/cors";
 import { prisma } from "@/lib/prisma";
+import { ZoneStatus } from "@prisma/client";
+import crypto from "crypto";
 
-export async function GET() {
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const where: any = {};
+  if (url.searchParams.get("regionId")) {
+    where.regionId = url.searchParams.get("regionId");
+  }
+  if (url.searchParams.get("zoneTypeId")) {
+    where.zoneTypeId = url.searchParams.get("zoneTypeId");
+  }
+  if (url.searchParams.get("status")) {
+    where.status = url.searchParams.get("status") as ZoneStatus;
+  }
+  if (url.searchParams.get("minArea")) {
+    where.totalArea = { gte: parseFloat(url.searchParams.get("minArea") as string) };
+  }
+  if (url.searchParams.get("maxArea")) {
+    where.totalArea = { ...(where.totalArea || {}), lte: parseFloat(url.searchParams.get("maxArea") as string) };
+  }
+  if (url.searchParams.get("minPrice")) {
+    where.price = { gte: parseFloat(url.searchParams.get("minPrice") as string) };
+  }
+  if (url.searchParams.get("maxPrice")) {
+    where.price = { ...(where.price || {}), lte: parseFloat(url.searchParams.get("maxPrice") as string) };
+  }
+
   const zones = await prisma.zone.findMany({
+    where,
     include: {
-      parcels: true,
+      parcels: { include: { vertices: true } },
       region: true,
       zoneType: true,
+      activities: { include: { activity: true } },
+      amenities: { include: { amenity: true } },
+      vertices: true,
     },
   });
-  return Response.json(zones);
+  return applyCors(Response.json(zones));
 }
 
 export async function POST(req: Request) {
   try {
     const data = await req.json();
-    const zone = await prisma.zone.create({ data });
-    return Response.json(zone, { status: 201 });
+    const { vertices, activityIds, amenityIds, ...zoneData } = data;
+
+    const zone = await prisma.zone.create({
+      data: {
+        ...zoneData,
+        vertices: Array.isArray(vertices)
+          ? { createMany: { data: vertices } }
+          : undefined,
+      },
+    });
+
+    if (Array.isArray(activityIds)) {
+      await prisma.zoneActivity.createMany({
+        data: activityIds.map((id: string) => ({
+          id: crypto.randomUUID(),
+          zoneId: zone.id,
+          activityId: id,
+        })),
+      });
+    }
+
+    if (Array.isArray(amenityIds)) {
+      await prisma.zoneAmenity.createMany({
+        data: amenityIds.map((id: string) => ({
+          id: crypto.randomUUID(),
+          zoneId: zone.id,
+          amenityId: id,
+        })),
+      });
+    }
+
+    const full = await prisma.zone.findUnique({
+      where: { id: zone.id },
+      include: {
+        parcels: { include: { vertices: true } },
+        region: true,
+        zoneType: true,
+        activities: { include: { activity: true } },
+        amenities: { include: { amenity: true } },
+        vertices: true,
+      },
+    });
+
+    return applyCors(Response.json(full, { status: 201 }));
   } catch (error) {
-    return new Response('Invalid data', { status: 400 });
+    return applyCors(new Response('Invalid data', { status: 400 }));
   }
+}
+
+export function OPTIONS() {
+  return corsOptions();
 }

--- a/Back-End/src/lib/cors.ts
+++ b/Back-End/src/lib/cors.ts
@@ -1,0 +1,10 @@
+export function applyCors(res: Response): Response {
+  res.headers.set('Access-Control-Allow-Origin', '*');
+  res.headers.set('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
+  res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  return res;
+}
+
+export function corsOptions() {
+  return applyCors(new Response(null, { status: 204 }));
+}

--- a/Front-End/package.json
+++ b/Front-End/package.json
@@ -28,8 +28,8 @@
     "tailwindcss-animate": "^1.0.7",
     "zod": "^4.0.5",
     "leaflet": "^1.9.4",
-    "react-leaflet": "^5.0.0",
-    "react-leaflet-draw": "^0.19.0"
+    "react-leaflet": "^5.0.0"
+    , "proj4": "^2.9.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/Front-End/src/app/admin/activities/page.tsx
+++ b/Front-End/src/app/admin/activities/page.tsx
@@ -7,20 +7,39 @@ import { Card, CardHeader, CardContent, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { fetchApi } from '@/lib/utils'
+import Pagination from '@/components/Pagination'
 
-interface Activity { id: string; name: string }
+interface Activity {
+  id: string
+  name: string
+  description?: string
+  icon?: string
+}
 
 export default function ActivitiesAdmin() {
   const { data: session } = useSession()
   const router = useRouter()
   const [items, setItems] = useState<Activity[]>([])
-  const [form, setForm] = useState<Activity>({ id: '', name: '' })
+  const [currentPage, setCurrentPage] = useState(1)
+  const itemsPerPage = 10
+  const [open, setOpen] = useState(false)
+  const [form, setForm] = useState<Activity>({
+    id: '',
+    name: '',
+    description: '',
+    icon: '',
+  })
 
   useEffect(() => { if (session && session.user.role !== 'ADMIN') router.push('/auth/login') }, [session])
 
   async function load() {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/activities`)
-    if (res.ok) setItems(await res.json())
+    const items = await fetchApi<Activity[]>('/api/activities')
+    if (items) {
+      setItems(items)
+      setCurrentPage(1)
+    }
   }
   useEffect(() => { load() }, [])
 
@@ -30,54 +49,115 @@ export default function ActivitiesAdmin() {
 
   async function submit(e: React.FormEvent) {
     e.preventDefault()
+    const body = {
+      name: form.name,
+      description: form.description || undefined,
+      icon: form.icon || undefined,
+    }
     if (form.id) {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/activities/${form.id}`, {
-        method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: form.name })
+      await fetchApi(`/api/activities/${form.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
       })
     } else {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/activities`, {
-        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: form.name })
+      await fetchApi('/api/activities', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
       })
     }
-    setForm({ id: '', name: '' })
+    setForm({ id: '', name: '', description: '', icon: '' })
+    setOpen(false)
     load()
   }
 
-  function edit(it: Activity) { setForm(it) }
+  function edit(it: Activity) {
+    setForm({
+      id: it.id,
+      name: it.name,
+      description: it.description ?? '',
+      icon: it.icon ?? '',
+    })
+    setOpen(true)
+  }
   async function del(id: string) {
-    await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/activities/${id}`, { method: 'DELETE' })
+    await fetchApi(`/api/activities/${id}`, { method: 'DELETE' })
     load()
+  }
+
+  function addNew() {
+    setForm({ id: '', name: '', description: '', icon: '' })
+    setOpen(true)
   }
 
   return (
     <div className="p-4 space-y-6">
-      <h1 className="text-xl font-bold">Activités</h1>
+      <div className="flex justify-between items-center">
+        <h1 className="text-xl font-bold">Activités</h1>
+        <Button onClick={addNew}>Ajouter</Button>
+      </div>
       <Card>
-        <CardContent className="divide-y">
-          {items.map(a => (
-            <div key={a.id} className="flex justify-between items-center py-2">
-              <span>{a.name}</span>
-              <div className="space-x-2">
-                <Button size="sm" onClick={() => edit(a)}>Éditer</Button>
-                <Button size="sm" variant="destructive" onClick={() => del(a.id)}>Supprimer</Button>
-              </div>
-            </div>
-          ))}
+        <CardContent className="overflow-x-auto p-0">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left">
+                <th className="p-2">Nom</th>
+                <th className="p-2">Description</th>
+                <th className="p-2">Icône</th>
+                <th className="p-2 w-32"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {items
+                .slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage)
+                .map((a) => (
+                <tr key={a.id} className="border-b last:border-0">
+                  <td className="p-2 align-top">{a.name}</td>
+                  <td className="p-2 align-top">{a.description}</td>
+                  <td className="p-2 align-top">{a.icon}</td>
+                  <td className="p-2 space-x-2 whitespace-nowrap">
+                    <Button size="sm" onClick={() => edit(a)}>Éditer</Button>
+                    <Button size="sm" variant="destructive" onClick={() => del(a.id)}>
+                      Supprimer
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader><CardTitle>{form.id ? 'Modifier' : 'Nouvelle activité'}</CardTitle></CardHeader>
-        <CardContent>
+      <Pagination
+        totalItems={items.length}
+        itemsPerPage={itemsPerPage}
+        currentPage={currentPage}
+        onPageChange={setCurrentPage}
+      />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{form.id ? 'Modifier' : 'Nouvelle activité'}</DialogTitle>
+          </DialogHeader>
           <form onSubmit={submit} className="space-y-4">
             <div>
               <Label htmlFor="name">Nom</Label>
               <Input id="name" name="name" value={form.name} onChange={handleChange} required />
             </div>
+            <div>
+              <Label htmlFor="description">Description</Label>
+              <Input id="description" name="description" value={form.description} onChange={handleChange} />
+            </div>
+            <div>
+              <Label htmlFor="icon">Icône</Label>
+              <Input id="icon" name="icon" value={form.icon} onChange={handleChange} />
+            </div>
             <Button type="submit">{form.id ? 'Mettre à jour' : 'Créer'}</Button>
           </form>
-        </CardContent>
-      </Card>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/Front-End/src/app/admin/amenities/page.tsx
+++ b/Front-End/src/app/admin/amenities/page.tsx
@@ -7,20 +7,41 @@ import { Card, CardHeader, CardContent, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { fetchApi } from '@/lib/utils'
+import Pagination from '@/components/Pagination'
 
-interface Amenity { id: string; name: string }
+interface Amenity {
+  id: string
+  name: string
+  description?: string
+  icon?: string
+  category?: string
+}
 
 export default function AmenitiesAdmin() {
   const { data: session } = useSession()
   const router = useRouter()
   const [items, setItems] = useState<Amenity[]>([])
-  const [form, setForm] = useState<Amenity>({ id: '', name: '' })
+  const [currentPage, setCurrentPage] = useState(1)
+  const itemsPerPage = 10
+  const [open, setOpen] = useState(false)
+  const [form, setForm] = useState<Amenity>({
+    id: '',
+    name: '',
+    description: '',
+    icon: '',
+    category: '',
+  })
 
   useEffect(() => { if (session && session.user.role !== 'ADMIN') router.push('/auth/login') }, [session])
 
   async function load() {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/amenities`)
-    if (res.ok) setItems(await res.json())
+    const items = await fetchApi<Amenity[]>('/api/amenities')
+    if (items) {
+      setItems(items)
+      setCurrentPage(1)
+    }
   }
   useEffect(() => { load() }, [])
 
@@ -30,54 +51,121 @@ export default function AmenitiesAdmin() {
 
   async function submit(e: React.FormEvent) {
     e.preventDefault()
+    const body = {
+      name: form.name,
+      description: form.description || undefined,
+      icon: form.icon || undefined,
+      category: form.category || undefined,
+    }
     if (form.id) {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/amenities/${form.id}`, {
-        method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: form.name })
+      await fetchApi(`/api/amenities/${form.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
       })
     } else {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/amenities`, {
-        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: form.name })
+      await fetchApi('/api/amenities', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
       })
     }
-    setForm({ id: '', name: '' })
+    setForm({ id: '', name: '', description: '', icon: '', category: '' })
+    setOpen(false)
     load()
   }
 
-  function edit(it: Amenity) { setForm(it) }
+  function edit(it: Amenity) {
+    setForm({
+      id: it.id,
+      name: it.name,
+      description: it.description ?? '',
+      icon: it.icon ?? '',
+      category: it.category ?? '',
+    })
+    setOpen(true)
+  }
   async function del(id: string) {
-    await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/amenities/${id}`, { method: 'DELETE' })
+    await fetchApi(`/api/amenities/${id}`, { method: 'DELETE' })
     load()
+  }
+
+  function addNew() {
+    setForm({ id: '', name: '', description: '', icon: '', category: '' })
+    setOpen(true)
   }
 
   return (
     <div className="p-4 space-y-6">
-      <h1 className="text-xl font-bold">Équipements</h1>
+      <div className="flex justify-between items-center">
+        <h1 className="text-xl font-bold">Équipements</h1>
+        <Button onClick={addNew}>Ajouter</Button>
+      </div>
       <Card>
-        <CardContent className="divide-y">
-          {items.map(a => (
-            <div key={a.id} className="flex justify-between items-center py-2">
-              <span>{a.name}</span>
-              <div className="space-x-2">
-                <Button size="sm" onClick={() => edit(a)}>Éditer</Button>
-                <Button size="sm" variant="destructive" onClick={() => del(a.id)}>Supprimer</Button>
-              </div>
-            </div>
-          ))}
+        <CardContent className="overflow-x-auto p-0">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left">
+                <th className="p-2">Nom</th>
+                <th className="p-2">Catégorie</th>
+                <th className="p-2">Icône</th>
+                <th className="p-2 w-32"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {items
+                .slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage)
+                .map((a) => (
+                <tr key={a.id} className="border-b last:border-0">
+                  <td className="p-2 align-top">{a.name}</td>
+                  <td className="p-2 align-top">{a.category}</td>
+                  <td className="p-2 align-top">{a.icon}</td>
+                  <td className="p-2 space-x-2 whitespace-nowrap">
+                    <Button size="sm" onClick={() => edit(a)}>Éditer</Button>
+                    <Button size="sm" variant="destructive" onClick={() => del(a.id)}>
+                      Supprimer
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader><CardTitle>{form.id ? 'Modifier' : 'Nouvel équipement'}</CardTitle></CardHeader>
-        <CardContent>
+      <Pagination
+        totalItems={items.length}
+        itemsPerPage={itemsPerPage}
+        currentPage={currentPage}
+        onPageChange={setCurrentPage}
+      />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{form.id ? 'Modifier' : 'Nouvel équipement'}</DialogTitle>
+          </DialogHeader>
           <form onSubmit={submit} className="space-y-4">
             <div>
               <Label htmlFor="name">Nom</Label>
               <Input id="name" name="name" value={form.name} onChange={handleChange} required />
             </div>
+            <div>
+              <Label htmlFor="description">Description</Label>
+              <Input id="description" name="description" value={form.description} onChange={handleChange} />
+            </div>
+            <div>
+              <Label htmlFor="icon">Icône</Label>
+              <Input id="icon" name="icon" value={form.icon} onChange={handleChange} />
+            </div>
+            <div>
+              <Label htmlFor="category">Catégorie</Label>
+              <Input id="category" name="category" value={form.category} onChange={handleChange} />
+            </div>
             <Button type="submit">{form.id ? 'Mettre à jour' : 'Créer'}</Button>
           </form>
-        </CardContent>
-      </Card>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/Front-End/src/app/admin/appointments/page.tsx
+++ b/Front-End/src/app/admin/appointments/page.tsx
@@ -7,24 +7,63 @@ import { Card, CardHeader, CardContent, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { fetchApi } from '@/lib/utils'
+import Pagination from '@/components/Pagination'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select'
 
 interface Appointment {
   id: string
   contactName: string
+  contactEmail: string
+  contactPhone: string
+  companyName: string
+  message: string
+  requestedDate: string
+  parcelId: string
   status: string
 }
+
+const statuses = ['PENDING', 'CONFIRMED', 'COMPLETED', 'CANCELLED']
 
 export default function AppointmentsAdmin() {
   const { data: session } = useSession()
   const router = useRouter()
   const [items, setItems] = useState<Appointment[]>([])
-  const [form, setForm] = useState<Appointment>({ id: '', contactName: '', status: 'PENDING' })
+  const [currentPage, setCurrentPage] = useState(1)
+  const itemsPerPage = 10
+  const [open, setOpen] = useState(false)
+  const [parcels, setParcels] = useState<{ id: string; reference: string }[]>([])
+  const [form, setForm] = useState<Appointment>({
+    id: '',
+    contactName: '',
+    contactEmail: '',
+    contactPhone: '',
+    companyName: '',
+    message: '',
+    requestedDate: '',
+    parcelId: '',
+    status: 'PENDING',
+  })
 
   useEffect(() => { if (session && session.user.role !== 'ADMIN' && session.user.role !== 'MANAGER') router.push('/auth/login') }, [session])
 
   async function load() {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/appointments`)
-    if (res.ok) setItems(await res.json())
+    const [a, p] = await Promise.all([
+      fetchApi<Appointment[]>('/api/appointments'),
+      fetchApi<{ id: string; reference: string }[]>('/api/parcels'),
+    ])
+    if (a) {
+      setItems(a)
+      setCurrentPage(1)
+    }
+    if (p) setParcels(p)
   }
   useEffect(() => { load() }, [])
 
@@ -32,60 +71,194 @@ export default function AppointmentsAdmin() {
     setForm({ ...form, [e.target.name]: e.target.value })
   }
 
+  const handleStatus = (value: string) => {
+    setForm({ ...form, status: value })
+  }
+
+  const handleParcel = (value: string) => {
+    setForm({ ...form, parcelId: value })
+  }
+
   async function submit(e: React.FormEvent) {
     e.preventDefault()
+    const body = {
+      contactName: form.contactName,
+      contactEmail: form.contactEmail || undefined,
+      contactPhone: form.contactPhone || undefined,
+      companyName: form.companyName || undefined,
+      message: form.message || undefined,
+      requestedDate: form.requestedDate || undefined,
+      parcelId: form.parcelId || undefined,
+      status: form.status,
+    }
+
     if (form.id) {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/appointments/${form.id}`, {
-        method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ contactName: form.contactName, status: form.status })
+      await fetchApi(`/api/appointments/${form.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
       })
     } else {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/appointments`, {
-        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ contactName: form.contactName, status: form.status })
+      await fetchApi('/api/appointments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
       })
     }
-    setForm({ id: '', contactName: '', status: 'PENDING' })
+    setForm({
+      id: '',
+      contactName: '',
+      contactEmail: '',
+      contactPhone: '',
+      companyName: '',
+      message: '',
+      requestedDate: '',
+      parcelId: '',
+      status: 'PENDING',
+    })
+    setOpen(false)
     load()
   }
 
-  function edit(it: Appointment) { setForm(it) }
+  function edit(it: Appointment) {
+    setForm({
+      id: it.id,
+      contactName: it.contactName,
+      contactEmail: it.contactEmail ?? '',
+      contactPhone: it.contactPhone ?? '',
+      companyName: it.companyName ?? '',
+      message: it.message ?? '',
+      requestedDate: it.requestedDate ? it.requestedDate.slice(0, 10) : '',
+      parcelId: it.parcelId ?? '',
+      status: it.status,
+    })
+    setOpen(true)
+  }
   async function del(id: string) {
-    await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/appointments/${id}`, { method: 'DELETE' })
+    await fetchApi(`/api/appointments/${id}`, { method: 'DELETE' })
     load()
+  }
+
+  function addNew() {
+    setForm({
+      id: '',
+      contactName: '',
+      contactEmail: '',
+      contactPhone: '',
+      companyName: '',
+      message: '',
+      requestedDate: '',
+      parcelId: '',
+      status: 'PENDING',
+    })
+    setOpen(true)
   }
 
   return (
     <div className="p-4 space-y-6">
-      <h1 className="text-xl font-bold">Rendez-vous</h1>
+      <div className="flex justify-between items-center">
+        <h1 className="text-xl font-bold">Rendez-vous</h1>
+        <Button onClick={addNew}>Ajouter</Button>
+      </div>
       <Card>
-        <CardContent className="divide-y">
-          {items.map(a => (
-            <div key={a.id} className="flex justify-between items-center py-2">
-              <span>{a.contactName}</span>
-              <div className="space-x-2">
-                <Button size="sm" onClick={() => edit(a)}>Éditer</Button>
-                <Button size="sm" variant="destructive" onClick={() => del(a.id)}>Supprimer</Button>
-              </div>
-            </div>
-          ))}
+        <CardContent className="overflow-x-auto p-0">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left">
+                <th className="p-2">Contact</th>
+                <th className="p-2">Statut</th>
+                <th className="p-2">Parcelle</th>
+                <th className="p-2 w-32"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {items
+                .slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage)
+                .map((a) => (
+                <tr key={a.id} className="border-b last:border-0">
+                  <td className="p-2 align-top">{a.contactName}</td>
+                  <td className="p-2 align-top">{a.status}</td>
+                  <td className="p-2 align-top">{a.parcelId}</td>
+                  <td className="p-2 space-x-2 whitespace-nowrap">
+                    <Button size="sm" onClick={() => edit(a)}>Éditer</Button>
+                    <Button size="sm" variant="destructive" onClick={() => del(a.id)}>
+                      Supprimer
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader><CardTitle>{form.id ? 'Modifier' : 'Nouveau RDV'}</CardTitle></CardHeader>
-        <CardContent>
+      <Pagination
+        totalItems={items.length}
+        itemsPerPage={itemsPerPage}
+        currentPage={currentPage}
+        onPageChange={setCurrentPage}
+      />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{form.id ? 'Modifier' : 'Nouveau RDV'}</DialogTitle>
+          </DialogHeader>
           <form onSubmit={submit} className="space-y-4">
             <div>
               <Label htmlFor="contactName">Contact</Label>
               <Input id="contactName" name="contactName" value={form.contactName} onChange={handleChange} required />
             </div>
             <div>
+              <Label htmlFor="contactEmail">Email</Label>
+              <Input id="contactEmail" name="contactEmail" value={form.contactEmail} onChange={handleChange} />
+            </div>
+            <div>
+              <Label htmlFor="contactPhone">Téléphone</Label>
+              <Input id="contactPhone" name="contactPhone" value={form.contactPhone} onChange={handleChange} />
+            </div>
+            <div>
+              <Label htmlFor="companyName">Société</Label>
+              <Input id="companyName" name="companyName" value={form.companyName} onChange={handleChange} />
+            </div>
+            <div>
+              <Label htmlFor="message">Message</Label>
+              <Input id="message" name="message" value={form.message} onChange={handleChange} />
+            </div>
+            <div>
+              <Label htmlFor="requestedDate">Date souhaitée</Label>
+              <Input id="requestedDate" name="requestedDate" type="date" value={form.requestedDate} onChange={handleChange} />
+            </div>
+            <div>
+              <Label htmlFor="parcelId">Parcelle</Label>
+              <Select value={form.parcelId} onValueChange={handleParcel}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Choisir" />
+                </SelectTrigger>
+                <SelectContent>
+                  {parcels.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>{p.reference}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
               <Label htmlFor="status">Statut</Label>
-              <Input id="status" name="status" value={form.status} onChange={handleChange} />
+              <Select value={form.status} onValueChange={handleStatus}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Choisir" />
+                </SelectTrigger>
+                <SelectContent>
+                  {statuses.map((s) => (
+                    <SelectItem key={s} value={s}>{s}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
             <Button type="submit">{form.id ? 'Mettre à jour' : 'Créer'}</Button>
           </form>
-        </CardContent>
-      </Card>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/Front-End/src/app/admin/layout.tsx
+++ b/Front-End/src/app/admin/layout.tsx
@@ -1,0 +1,10 @@
+import AdminHeader from '@/components/AdminHeader';
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <AdminHeader />
+      <main className="pt-6">{children}</main>
+    </>
+  );
+}

--- a/Front-End/src/app/admin/page.tsx
+++ b/Front-End/src/app/admin/page.tsx
@@ -6,6 +6,7 @@ import { authOptions } from '@/lib/auth';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { fetchApi } from '@/lib/utils';
 import {
   Users,
   MapPin,
@@ -21,16 +22,11 @@ import {
 import Link from 'next/link';
 
 async function getAdminStats() {
-  const base = process.env.NEXT_PUBLIC_API_URL || '';
-  const res = await fetch(`${base}/api/admin/stats`, { 
-    cache: 'no-store',
-    // Ajouter un timeout pour éviter les blocages
-    next: { revalidate: 0 }
-  });
-  if (!res.ok) {
+  const data = await fetchApi('/api/admin/stats');
+  if (!data) {
     throw new Error('Unable to load admin stats');
   }
-  return res.json();
+  return data;
 }
 
 export default async function AdminDashboard() {

--- a/Front-End/src/app/admin/parcels/page.tsx
+++ b/Front-End/src/app/admin/parcels/page.tsx
@@ -7,25 +7,100 @@ import { Card, CardHeader, CardContent, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { fetchApi } from '@/lib/utils'
+import Pagination from '@/components/Pagination'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select'
+
+interface Vertex {
+  seq: number
+  lambertX: number
+  lambertY: number
+}
 
 interface Parcel {
   id: string
   reference: string
-  zoneId: string
+  area?: number | null
+  price?: number | null
   status: string
+  isFree?: boolean | null
+  isShowroom?: boolean | null
+  cos?: number | null
+  cus?: number | null
+  latitude?: number | null
+  longitude?: number | null
+  lambertX?: number | null
+  lambertY?: number | null
+  zoneId: string
+  vertices?: Vertex[]
 }
+
+interface ParcelForm {
+  id: string
+  reference: string
+  area: string
+  price: string
+  status: string
+  isFree: boolean
+  isShowroom: boolean
+  cos: string
+  cus: string
+  latitude: string
+  longitude: string
+  lambertX: string
+  lambertY: string
+  zoneId: string
+  vertices: { lambertX: string; lambertY: string }[]
+}
+
+const statuses = ['AVAILABLE', 'RESERVED', 'OCCUPIED', 'SHOWROOM']
 
 export default function ParcelsAdmin() {
   const { data: session } = useSession()
   const router = useRouter()
   const [items, setItems] = useState<Parcel[]>([])
-  const [form, setForm] = useState<Parcel>({ id: '', reference: '', zoneId: '', status: 'AVAILABLE' })
+  const [currentPage, setCurrentPage] = useState(1)
+  const itemsPerPage = 10
+  const [open, setOpen] = useState(false)
+  const [zones, setZones] = useState<{ id: string; name: string }[]>([])
+  const [form, setForm] = useState<ParcelForm>({
+    id: '',
+    reference: '',
+    area: '',
+    price: '',
+    status: 'AVAILABLE',
+    isFree: true,
+    isShowroom: false,
+    cos: '',
+    cus: '',
+    latitude: '',
+    longitude: '',
+    lambertX: '',
+    lambertY: '',
+    zoneId: '',
+    vertices: [],
+  })
+  const [images, setImages] = useState<{ file: File; url: string }[]>([])
 
   useEffect(() => { if (session && session.user.role !== 'ADMIN' && session.user.role !== 'MANAGER') router.push('/auth/login') }, [session])
 
   async function load() {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/parcels`)
-    if (res.ok) setItems(await res.json())
+    const [p, z] = await Promise.all([
+      fetchApi<Parcel[]>('/api/parcels'),
+      fetchApi<{ id: string; name: string }[]>('/api/zones'),
+    ])
+    if (p) {
+      setItems(p)
+      setCurrentPage(1)
+    }
+    if (z) setZones(z)
   }
   useEffect(() => { load() }, [])
 
@@ -33,64 +108,350 @@ export default function ParcelsAdmin() {
     setForm({ ...form, [e.target.name]: e.target.value })
   }
 
+  const handleToggle = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.checked })
+  }
+
+  const handleStatus = (value: string) => {
+    setForm({ ...form, status: value })
+  }
+
+  const handleZone = (value: string) => {
+    setForm({ ...form, zoneId: value })
+  }
+
+  const addVertex = () => {
+    setForm((f) => ({
+      ...f,
+      vertices: [...f.vertices, { lambertX: '', lambertY: '' }],
+    }))
+  }
+
+  const updateVertex = (
+    index: number,
+    field: 'lambertX' | 'lambertY',
+    value: string
+  ) => {
+    setForm((f) => {
+      const verts = [...f.vertices]
+      verts[index] = { ...verts[index], [field]: value }
+      return { ...f, vertices: verts }
+    })
+  }
+
+  const removeVertex = (index: number) => {
+    setForm((f) => {
+      const verts = [...f.vertices]
+      verts.splice(index, 1)
+      return { ...f, vertices: verts }
+    })
+  }
+
+  const handleFiles = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return
+    const files = Array.from(e.target.files).map((file) => ({
+      file,
+      url: URL.createObjectURL(file),
+    }))
+    setImages((imgs) => [...imgs, ...files])
+    e.target.value = ''
+  }
+
+  const removeImage = (idx: number) => {
+    setImages((imgs) => {
+      const copy = [...imgs]
+      URL.revokeObjectURL(copy[idx].url)
+      copy.splice(idx, 1)
+      return copy
+    })
+  }
+
   async function submit(e: React.FormEvent) {
     e.preventDefault()
+    const body = {
+      reference: form.reference,
+      area: form.area ? parseFloat(form.area) : undefined,
+      price: form.price ? parseFloat(form.price) : undefined,
+      status: form.status,
+      isFree: form.isFree,
+      isShowroom: form.isShowroom,
+      cos: form.cos ? parseFloat(form.cos) : undefined,
+      cus: form.cus ? parseFloat(form.cus) : undefined,
+      latitude: form.latitude ? parseFloat(form.latitude) : undefined,
+      longitude: form.longitude ? parseFloat(form.longitude) : undefined,
+      lambertX: form.lambertX ? parseFloat(form.lambertX) : undefined,
+      lambertY: form.lambertY ? parseFloat(form.lambertY) : undefined,
+      zoneId: form.zoneId,
+      vertices: form.vertices.map((v, i) => ({
+        seq: i,
+        lambertX: v.lambertX ? parseFloat(v.lambertX) : 0,
+        lambertY: v.lambertY ? parseFloat(v.lambertY) : 0,
+      })),
+    }
+
     if (form.id) {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/parcels/${form.id}`, {
-        method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ reference: form.reference, zoneId: form.zoneId, status: form.status })
+      await fetchApi(`/api/parcels/${form.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
       })
     } else {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/parcels`, {
-        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ reference: form.reference, zoneId: form.zoneId, status: form.status })
+      await fetchApi('/api/parcels', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
       })
     }
-    setForm({ id: '', reference: '', zoneId: '', status: 'AVAILABLE' })
+
+    setForm({
+      id: '',
+      reference: '',
+      area: '',
+      price: '',
+      status: 'AVAILABLE',
+      isFree: true,
+      isShowroom: false,
+      cos: '',
+      cus: '',
+      latitude: '',
+      longitude: '',
+      lambertX: '',
+      lambertY: '',
+      zoneId: '',
+      vertices: [],
+    })
+    setImages([])
+    setOpen(false)
     load()
   }
 
-  function edit(it: Parcel) { setForm(it) }
+  function edit(it: Parcel) {
+    setForm({
+      id: it.id,
+      reference: it.reference,
+      area: it.area?.toString() ?? '',
+      price: it.price?.toString() ?? '',
+      status: it.status,
+      isFree: it.isFree ?? true,
+      isShowroom: it.isShowroom ?? false,
+      cos: it.cos?.toString() ?? '',
+      cus: it.cus?.toString() ?? '',
+      latitude: it.latitude?.toString() ?? '',
+      longitude: it.longitude?.toString() ?? '',
+      lambertX: it.lambertX?.toString() ?? '',
+      lambertY: it.lambertY?.toString() ?? '',
+      zoneId: it.zoneId,
+      vertices: it.vertices ? it.vertices.sort((a,b)=>a.seq-b.seq).map(v=>({
+        lambertX: v.lambertX.toString(),
+        lambertY: v.lambertY.toString(),
+      })) : [],
+    })
+    setImages([])
+    setOpen(true)
+  }
   async function del(id: string) {
-    await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/parcels/${id}`, { method: 'DELETE' })
+    await fetchApi(`/api/parcels/${id}`, { method: 'DELETE' })
     load()
+  }
+
+  function addNew() {
+    setForm({
+      id: '',
+      reference: '',
+      area: '',
+      price: '',
+      status: 'AVAILABLE',
+      isFree: true,
+      isShowroom: false,
+      cos: '',
+      cus: '',
+      latitude: '',
+      longitude: '',
+      lambertX: '',
+      lambertY: '',
+      zoneId: '',
+      vertices: [],
+    })
+    setImages([])
+    setOpen(true)
   }
 
   return (
     <div className="p-4 space-y-6">
-      <h1 className="text-xl font-bold">Parcelles</h1>
+      <div className="flex justify-between items-center">
+        <h1 className="text-xl font-bold">Parcelles</h1>
+        <Button onClick={addNew}>Ajouter</Button>
+      </div>
       <Card>
-        <CardContent className="divide-y">
-          {items.map(p => (
-            <div key={p.id} className="flex justify-between items-center py-2">
-              <span>{p.reference}</span>
-              <div className="space-x-2">
-                <Button size="sm" onClick={() => edit(p)}>Éditer</Button>
-                <Button size="sm" variant="destructive" onClick={() => del(p.id)}>Supprimer</Button>
-              </div>
-            </div>
-          ))}
+        <CardContent className="overflow-x-auto p-0">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left">
+                <th className="p-2">Référence</th>
+                <th className="p-2">Zone</th>
+                <th className="p-2">Statut</th>
+                <th className="p-2 w-32"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {items
+                .slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage)
+                .map((p) => (
+                <tr key={p.id} className="border-b last:border-0">
+                  <td className="p-2 align-top">{p.reference}</td>
+                  <td className="p-2 align-top">{p.zoneId}</td>
+                  <td className="p-2 align-top">{p.status}</td>
+                  <td className="p-2 space-x-2 whitespace-nowrap">
+                    <Button size="sm" onClick={() => edit(p)}>Éditer</Button>
+                    <Button size="sm" variant="destructive" onClick={() => del(p.id)}>
+                      Supprimer
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader><CardTitle>{form.id ? 'Modifier' : 'Nouvelle parcelle'}</CardTitle></CardHeader>
-        <CardContent>
+      <Pagination
+        totalItems={items.length}
+        itemsPerPage={itemsPerPage}
+        currentPage={currentPage}
+        onPageChange={setCurrentPage}
+      />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{form.id ? 'Modifier' : 'Nouvelle parcelle'}</DialogTitle>
+          </DialogHeader>
           <form onSubmit={submit} className="space-y-4">
             <div>
               <Label htmlFor="reference">Référence</Label>
               <Input id="reference" name="reference" value={form.reference} onChange={handleChange} required />
             </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="area">Surface m²</Label>
+                <Input id="area" name="area" value={form.area} onChange={handleChange} />
+              </div>
+              <div>
+                <Label htmlFor="price">Prix</Label>
+                <Input id="price" name="price" value={form.price} onChange={handleChange} />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="latitude">Latitude</Label>
+                <Input id="latitude" name="latitude" value={form.latitude} onChange={handleChange} />
+              </div>
+              <div>
+                <Label htmlFor="longitude">Longitude</Label>
+                <Input id="longitude" name="longitude" value={form.longitude} onChange={handleChange} />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="lambertX">Lambert X</Label>
+                <Input id="lambertX" name="lambertX" value={form.lambertX} onChange={handleChange} />
+              </div>
+              <div>
+                <Label htmlFor="lambertY">Lambert Y</Label>
+                <Input id="lambertY" name="lambertY" value={form.lambertY} onChange={handleChange} />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="flex items-center gap-2">
+                <input type="checkbox" id="isFree" name="isFree" checked={form.isFree} onChange={handleToggle} />
+                <Label htmlFor="isFree">Libre</Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <input type="checkbox" id="isShowroom" name="isShowroom" checked={form.isShowroom} onChange={handleToggle} />
+                <Label htmlFor="isShowroom">Showroom</Label>
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="cos">CoS</Label>
+                <Input id="cos" name="cos" value={form.cos} onChange={handleChange} />
+              </div>
+              <div>
+                <Label htmlFor="cus">CuS</Label>
+                <Input id="cus" name="cus" value={form.cus} onChange={handleChange} />
+              </div>
+            </div>
+            <div>
+              <Label>Coordonnées Lambert (polygone)</Label>
+              {form.vertices.map((v, idx) => (
+                <div key={idx} className="grid grid-cols-2 gap-2 items-center mb-2">
+                  <Input
+                    placeholder="X"
+                    value={v.lambertX}
+                    onChange={(e) => updateVertex(idx, 'lambertX', e.target.value)}
+                  />
+                  <div className="flex gap-2">
+                    <Input
+                      placeholder="Y"
+                      value={v.lambertY}
+                      onChange={(e) => updateVertex(idx, 'lambertY', e.target.value)}
+                    />
+                    <Button type="button" size="sm" variant="destructive" onClick={() => removeVertex(idx)}>
+                      ×
+                    </Button>
+                  </div>
+                </div>
+              ))}
+              <Button type="button" size="sm" onClick={addVertex}>Ajouter un point</Button>
+            </div>
             <div>
               <Label htmlFor="zoneId">Zone</Label>
-              <Input id="zoneId" name="zoneId" value={form.zoneId} onChange={handleChange} required />
+              <Select value={form.zoneId} onValueChange={handleZone}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Choisir" />
+                </SelectTrigger>
+                <SelectContent>
+                  {zones.map((z) => (
+                    <SelectItem key={z.id} value={z.id}>{z.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
             <div>
               <Label htmlFor="status">Statut</Label>
-              <Input id="status" name="status" value={form.status} onChange={handleChange} />
+              <Select value={form.status} onValueChange={handleStatus}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Choisir" />
+                </SelectTrigger>
+                <SelectContent>
+                  {statuses.map((s) => (
+                    <SelectItem key={s} value={s}>{s}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label>Photos</Label>
+              <Input type="file" multiple onChange={handleFiles} />
+              <div className="flex flex-wrap gap-2 mt-2">
+                {images.map((img, idx) => (
+                  <div key={idx} className="relative">
+                    <img src={img.url} className="w-24 h-24 object-cover rounded" />
+                    <button
+                      type="button"
+                      onClick={() => removeImage(idx)}
+                      className="absolute top-0 right-0 bg-red-600 text-white rounded-full w-5 h-5 flex items-center justify-center"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
             </div>
             <Button type="submit">{form.id ? 'Mettre à jour' : 'Créer'}</Button>
           </form>
-        </CardContent>
-      </Card>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/Front-End/src/app/admin/regions/page.tsx
+++ b/Front-End/src/app/admin/regions/page.tsx
@@ -7,6 +7,16 @@ import { Card, CardHeader, CardContent, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { fetchApi } from '@/lib/utils'
+import Pagination from '@/components/Pagination'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select'
 
 interface Region {
   id: string
@@ -19,6 +29,10 @@ export default function RegionsAdmin() {
   const { data: session } = useSession()
   const router = useRouter()
   const [items, setItems] = useState<Region[]>([])
+  const [currentPage, setCurrentPage] = useState(1)
+  const itemsPerPage = 10
+  const [open, setOpen] = useState(false)
+  const [countries, setCountries] = useState<{ id: string; name: string }[]>([])
   const [form, setForm] = useState<Region>({ id: '', name: '', code: '', countryId: '' })
 
   useEffect(() => {
@@ -28,8 +42,15 @@ export default function RegionsAdmin() {
   }, [session])
 
   async function load() {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/regions`)
-    if (res.ok) setItems(await res.json())
+    const [r, c] = await Promise.all([
+      fetchApi<Region[]>('/api/regions'),
+      fetchApi<{ id: string; name: string }[]>('/api/countries'),
+    ])
+    if (r) {
+      setItems(r)
+      setCurrentPage(1)
+    }
+    if (c) setCountries(c)
   }
   useEffect(() => { load() }, [])
 
@@ -37,54 +58,95 @@ export default function RegionsAdmin() {
     setForm({ ...form, [e.target.name]: e.target.value })
   }
 
+  const handleCountry = (value: string) => {
+    setForm({ ...form, countryId: value })
+  }
+
   async function submit(e: React.FormEvent) {
     e.preventDefault()
     if (form.id) {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/regions/${form.id}`, {
+      await fetchApi(`/api/regions/${form.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: form.name, code: form.code, countryId: form.countryId })
       })
     } else {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/regions`, {
+      await fetchApi('/api/regions', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: form.name, code: form.code, countryId: form.countryId })
       })
     }
     setForm({ id: '', name: '', code: '', countryId: '' })
+    setOpen(false)
     load()
   }
 
-  function edit(it: Region) { setForm(it) }
+  function edit(it: Region) {
+    setForm(it)
+    setOpen(true)
+  }
 
   async function del(id: string) {
-    await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/regions/${id}`, { method: 'DELETE' })
+    await fetchApi(`/api/regions/${id}`, { method: 'DELETE' })
     load()
+  }
+
+  function addNew() {
+    setForm({ id: '', name: '', code: '', countryId: '' })
+    setOpen(true)
   }
 
   return (
     <div className="p-4 space-y-6">
-      <h1 className="text-xl font-bold">Gestion des Régions</h1>
+      <div className="flex justify-between items-center">
+        <h1 className="text-xl font-bold">Gestion des Régions</h1>
+        <Button onClick={addNew}>Ajouter</Button>
+      </div>
       <Card>
-        <CardContent className="divide-y">
-          {items.map(r => (
-            <div key={r.id} className="flex justify-between items-center py-2">
-              <span>{r.name} ({r.code})</span>
-              <div className="space-x-2">
-                <Button size="sm" onClick={() => edit(r)}>Éditer</Button>
-                <Button size="sm" variant="destructive" onClick={() => del(r.id)}>Supprimer</Button>
-              </div>
-            </div>
-          ))}
+        <CardContent className="overflow-x-auto p-0">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left">
+                <th className="p-2">Nom</th>
+                <th className="p-2">Code</th>
+                <th className="p-2">Pays</th>
+                <th className="p-2 w-32"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {items
+                .slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage)
+                .map((r) => (
+                <tr key={r.id} className="border-b last:border-0">
+                  <td className="p-2 align-top">{r.name}</td>
+                  <td className="p-2 align-top">{r.code}</td>
+                  <td className="p-2 align-top">{r.countryId}</td>
+                  <td className="p-2 space-x-2 whitespace-nowrap">
+                    <Button size="sm" onClick={() => edit(r)}>Éditer</Button>
+                    <Button size="sm" variant="destructive" onClick={() => del(r.id)}>
+                      Supprimer
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>{form.id ? 'Modifier une région' : 'Nouvelle région'}</CardTitle>
-        </CardHeader>
-        <CardContent>
+      <Pagination
+        totalItems={items.length}
+        itemsPerPage={itemsPerPage}
+        currentPage={currentPage}
+        onPageChange={setCurrentPage}
+      />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{form.id ? 'Modifier une région' : 'Nouvelle région'}</DialogTitle>
+          </DialogHeader>
           <form onSubmit={submit} className="space-y-4">
             <div>
               <Label htmlFor="name">Nom</Label>
@@ -96,12 +158,21 @@ export default function RegionsAdmin() {
             </div>
             <div>
               <Label htmlFor="countryId">Pays</Label>
-              <Input id="countryId" name="countryId" value={form.countryId} onChange={handleChange} required />
+              <Select value={form.countryId} onValueChange={handleCountry}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Choisir" />
+                </SelectTrigger>
+                <SelectContent>
+                  {countries.map((c) => (
+                    <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
             <Button type="submit">{form.id ? 'Mettre à jour' : 'Créer'}</Button>
           </form>
-        </CardContent>
-      </Card>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/Front-End/src/app/admin/users/page.tsx
+++ b/Front-End/src/app/admin/users/page.tsx
@@ -7,25 +7,55 @@ import { Card, CardHeader, CardContent, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { fetchApi } from '@/lib/utils'
+import Pagination from '@/components/Pagination'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select'
 
 interface User {
   id: string
   email: string
   name: string
   role: string
+  company?: string
+  phone?: string
+  isActive?: boolean
 }
+
+const roles = ['ADMIN', 'MANAGER', 'USER']
 
 export default function UsersAdmin() {
   const { data: session } = useSession()
   const router = useRouter()
   const [items, setItems] = useState<User[]>([])
-  const [form, setForm] = useState<User & { password?: string }>({ id: '', email: '', name: '', role: 'USER', password: '' })
+  const [currentPage, setCurrentPage] = useState(1)
+  const itemsPerPage = 10
+  const [open, setOpen] = useState(false)
+  const [form, setForm] = useState<User & { password?: string }>({
+    id: '',
+    email: '',
+    name: '',
+    role: 'USER',
+    company: '',
+    phone: '',
+    isActive: true,
+    password: '',
+  })
 
   useEffect(() => { if (session && session.user.role !== 'ADMIN') router.push('/auth/login') }, [session])
 
   async function load() {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/users`)
-    if (res.ok) setItems(await res.json())
+    const users = await fetchApi<User[]>('/api/users')
+    if (users) {
+      setItems(users)
+      setCurrentPage(1)
+    }
   }
   useEffect(() => { load() }, [])
 
@@ -33,48 +63,126 @@ export default function UsersAdmin() {
     setForm({ ...form, [e.target.name]: e.target.value })
   }
 
+  const handleRole = (value: string) => {
+    setForm({ ...form, role: value })
+  }
+
   async function submit(e: React.FormEvent) {
     e.preventDefault()
-    const body = { email: form.email, name: form.name, role: form.role, password: form.password }
+    const body = {
+      email: form.email,
+      name: form.name,
+      role: form.role,
+      company: form.company || undefined,
+      phone: form.phone || undefined,
+      isActive: form.isActive,
+      password: form.password,
+    }
     if (form.id) {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/users/${form.id}`, {
+      await fetchApi(`/api/users/${form.id}`, {
         method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body)
       })
     } else {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/users`, {
+      await fetchApi('/api/users', {
         method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body)
       })
     }
-    setForm({ id: '', email: '', name: '', role: 'USER', password: '' })
+    setForm({
+      id: '',
+      email: '',
+      name: '',
+      role: 'USER',
+      company: '',
+      phone: '',
+      isActive: true,
+      password: '',
+    })
+    setOpen(false)
     load()
   }
 
-  function edit(it: User) { setForm({ ...it, password: '' }) }
+  function edit(it: User) {
+    setForm({
+      id: it.id,
+      email: it.email,
+      name: it.name,
+      role: it.role,
+      company: it.company ?? '',
+      phone: it.phone ?? '',
+      isActive: it.isActive ?? true,
+      password: '',
+    })
+    setOpen(true)
+  }
   async function del(id: string) {
-    await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/users/${id}`, { method: 'DELETE' })
+    await fetchApi(`/api/users/${id}`, { method: 'DELETE' })
     load()
+  }
+
+  function addNew() {
+    setForm({
+      id: '',
+      email: '',
+      name: '',
+      role: 'USER',
+      company: '',
+      phone: '',
+      isActive: true,
+      password: '',
+    })
+    setOpen(true)
   }
 
   return (
     <div className="p-4 space-y-6">
-      <h1 className="text-xl font-bold">Utilisateurs</h1>
+      <div className="flex justify-between items-center">
+        <h1 className="text-xl font-bold">Utilisateurs</h1>
+        <Button onClick={addNew}>Ajouter</Button>
+      </div>
       <Card>
-        <CardContent className="divide-y">
-          {items.map(u => (
-            <div key={u.id} className="flex justify-between items-center py-2">
-              <span>{u.email}</span>
-              <div className="space-x-2">
-                <Button size="sm" onClick={() => edit(u)}>Éditer</Button>
-                <Button size="sm" variant="destructive" onClick={() => del(u.id)}>Supprimer</Button>
-              </div>
-            </div>
-          ))}
+        <CardContent className="overflow-x-auto p-0">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left">
+                <th className="p-2">Email</th>
+                <th className="p-2">Rôle</th>
+                <th className="p-2">Société</th>
+                <th className="p-2 w-32"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {items
+                .slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage)
+                .map((u) => (
+                <tr key={u.id} className="border-b last:border-0">
+                  <td className="p-2 align-top">{u.email}</td>
+                  <td className="p-2 align-top">{u.role}</td>
+                  <td className="p-2 align-top">{u.company}</td>
+                  <td className="p-2 space-x-2 whitespace-nowrap">
+                    <Button size="sm" onClick={() => edit(u)}>Éditer</Button>
+                    <Button size="sm" variant="destructive" onClick={() => del(u.id)}>
+                      Supprimer
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader><CardTitle>{form.id ? 'Modifier' : 'Nouvel utilisateur'}</CardTitle></CardHeader>
-        <CardContent>
+      <Pagination
+        totalItems={items.length}
+        itemsPerPage={itemsPerPage}
+        currentPage={currentPage}
+        onPageChange={setCurrentPage}
+      />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{form.id ? 'Modifier' : 'Nouvel utilisateur'}</DialogTitle>
+          </DialogHeader>
           <form onSubmit={submit} className="space-y-4">
             <div>
               <Label htmlFor="email">Email</Label>
@@ -85,8 +193,29 @@ export default function UsersAdmin() {
               <Input id="name" name="name" value={form.name} onChange={handleChange} />
             </div>
             <div>
+              <Label htmlFor="company">Société</Label>
+              <Input id="company" name="company" value={form.company} onChange={handleChange} />
+            </div>
+            <div>
+              <Label htmlFor="phone">Téléphone</Label>
+              <Input id="phone" name="phone" value={form.phone} onChange={handleChange} />
+            </div>
+            <div>
               <Label htmlFor="role">Rôle</Label>
-              <Input id="role" name="role" value={form.role} onChange={handleChange} />
+              <Select value={form.role} onValueChange={handleRole}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Choisir" />
+                </SelectTrigger>
+                <SelectContent>
+                  {roles.map((r) => (
+                    <SelectItem key={r} value={r}>{r}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center space-x-2">
+              <input id="isActive" name="isActive" type="checkbox" checked={form.isActive} onChange={(e) => setForm({ ...form, isActive: e.target.checked })} />
+              <Label htmlFor="isActive">Actif</Label>
             </div>
             <div>
               <Label htmlFor="password">Mot de passe</Label>
@@ -94,8 +223,8 @@ export default function UsersAdmin() {
             </div>
             <Button type="submit">{form.id ? 'Mettre à jour' : 'Créer'}</Button>
           </form>
-        </CardContent>
-      </Card>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/Front-End/src/app/admin/zone-types/page.tsx
+++ b/Front-End/src/app/admin/zone-types/page.tsx
@@ -7,6 +7,9 @@ import { Card, CardHeader, CardContent, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { fetchApi } from '@/lib/utils'
+import Pagination from '@/components/Pagination'
 
 interface ZoneType {
   id: string
@@ -17,6 +20,9 @@ export default function ZoneTypesAdmin() {
   const { data: session } = useSession()
   const router = useRouter()
   const [items, setItems] = useState<ZoneType[]>([])
+  const [currentPage, setCurrentPage] = useState(1)
+  const itemsPerPage = 10
+  const [open, setOpen] = useState(false)
   const [form, setForm] = useState<ZoneType>({ id: '', name: '' })
 
   useEffect(() => {
@@ -24,8 +30,11 @@ export default function ZoneTypesAdmin() {
   }, [session])
 
   async function load() {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/zone-types`)
-    if (res.ok) setItems(await res.json())
+    const items = await fetchApi<ZoneType[]>('/api/zone-types')
+    if (items) {
+      setItems(items)
+      setCurrentPage(1)
+    }
   }
   useEffect(() => { load() }, [])
 
@@ -36,51 +45,84 @@ export default function ZoneTypesAdmin() {
   async function submit(e: React.FormEvent) {
     e.preventDefault()
     if (form.id) {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/zone-types/${form.id}`, {
+      await fetchApi(`/api/zone-types/${form.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: form.name })
       })
     } else {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/zone-types`, {
+      await fetchApi('/api/zone-types', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: form.name })
       })
     }
     setForm({ id: '', name: '' })
+    setOpen(false)
     load()
   }
 
-  function edit(it: ZoneType) { setForm(it) }
+  function edit(it: ZoneType) {
+    setForm(it)
+    setOpen(true)
+  }
 
   async function del(id: string) {
-    await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/zone-types/${id}`, { method: 'DELETE' })
+    await fetchApi(`/api/zone-types/${id}`, { method: 'DELETE' })
     load()
+  }
+
+  function addNew() {
+    setForm({ id: '', name: '' })
+    setOpen(true)
   }
 
   return (
     <div className="p-4 space-y-6">
-      <h1 className="text-xl font-bold">Types de zone</h1>
+      <div className="flex justify-between items-center">
+        <h1 className="text-xl font-bold">Types de zone</h1>
+        <Button onClick={addNew}>Ajouter</Button>
+      </div>
       <Card>
-        <CardContent className="divide-y">
-          {items.map(t => (
-            <div key={t.id} className="flex justify-between items-center py-2">
-              <span>{t.name}</span>
-              <div className="space-x-2">
-                <Button size="sm" onClick={() => edit(t)}>Éditer</Button>
-                <Button size="sm" variant="destructive" onClick={() => del(t.id)}>Supprimer</Button>
-              </div>
-            </div>
-          ))}
+        <CardContent className="overflow-x-auto p-0">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left">
+                <th className="p-2">Nom</th>
+                <th className="p-2 w-32"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {items
+                .slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage)
+                .map((t) => (
+                <tr key={t.id} className="border-b last:border-0">
+                  <td className="p-2 align-top">{t.name}</td>
+                  <td className="p-2 space-x-2 whitespace-nowrap">
+                    <Button size="sm" onClick={() => edit(t)}>Éditer</Button>
+                    <Button size="sm" variant="destructive" onClick={() => del(t.id)}>
+                      Supprimer
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>{form.id ? 'Modifier' : 'Nouveau type'}</CardTitle>
-        </CardHeader>
-        <CardContent>
+      <Pagination
+        totalItems={items.length}
+        itemsPerPage={itemsPerPage}
+        currentPage={currentPage}
+        onPageChange={setCurrentPage}
+      />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{form.id ? 'Modifier' : 'Nouveau type'}</DialogTitle>
+          </DialogHeader>
           <form onSubmit={submit} className="space-y-4">
             <div>
               <Label htmlFor="name">Nom</Label>
@@ -88,8 +130,8 @@ export default function ZoneTypesAdmin() {
             </div>
             <Button type="submit">{form.id ? 'Mettre à jour' : 'Créer'}</Button>
           </form>
-        </CardContent>
-      </Card>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/Front-End/src/app/admin/zones/page.tsx
+++ b/Front-End/src/app/admin/zones/page.tsx
@@ -7,18 +7,98 @@ import { Card, CardHeader, CardContent, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { fetchApi } from '@/lib/utils'
+import Pagination from '@/components/Pagination'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select'
+
+interface Vertex {
+  seq: number
+  lambertX: number
+  lambertY: number
+}
 
 interface Zone {
   id: string
   name: string
+  description?: string | null
+  address?: string | null
+  totalArea?: number | null
+  price?: number | null
   status: string
+  latitude?: number | null
+  longitude?: number | null
+  lambertX?: number | null
+  lambertY?: number | null
+  zoneTypeId?: string | null
+  regionId?: string | null
+  activities?: { activityId: string }[]
+  amenities?: { amenityId: string }[]
+  vertices?: Vertex[]
 }
+
+interface ZoneForm {
+  id: string
+  name: string
+  description: string
+  address: string
+  totalArea: string
+  price: string
+  status: string
+  latitude: string
+  longitude: string
+  lambertX: string
+  lambertY: string
+  zoneTypeId: string
+  regionId: string
+  activityIds: string[]
+  amenityIds: string[]
+  vertices: { lambertX: string; lambertY: string }[]
+}
+
+const statuses = [
+  'AVAILABLE',
+  'RESERVED',
+  'OCCUPIED',
+  'SHOWROOM',
+]
 
 export default function ZonesAdmin() {
   const { data: session } = useSession()
   const router = useRouter()
   const [zones, setZones] = useState<Zone[]>([])
-  const [form, setForm] = useState<Zone>({ id: '', name: '', status: 'AVAILABLE' })
+  const [currentPage, setCurrentPage] = useState(1)
+  const itemsPerPage = 10
+  const [open, setOpen] = useState(false)
+  const [zoneTypes, setZoneTypes] = useState<{ id: string; name: string }[]>([])
+  const [regions, setRegions] = useState<{ id: string; name: string }[]>([])
+  const [activities, setActivities] = useState<{ id: string; name: string }[]>([])
+  const [amenities, setAmenities] = useState<{ id: string; name: string }[]>([])
+  const [form, setForm] = useState<ZoneForm>({
+    id: '',
+    name: '',
+    description: '',
+    address: '',
+    totalArea: '',
+    price: '',
+    status: 'AVAILABLE',
+    latitude: '',
+    longitude: '',
+    lambertX: '',
+    lambertY: '',
+    zoneTypeId: '',
+    regionId: '',
+    activityIds: [],
+    amenityIds: [],
+    vertices: [],
+  })
+  const [images, setImages] = useState<{ file: File; url: string }[]>([])
 
   useEffect(() => {
     if (session && session.user.role !== 'ADMIN' && session.user.role !== 'MANAGER') {
@@ -27,10 +107,21 @@ export default function ZonesAdmin() {
   }, [session])
 
   async function load() {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/zones`)
-    if (res.ok) {
-      setZones(await res.json())
+    const [z, t, r, a, m] = await Promise.all([
+      fetchApi<Zone[]>('/api/zones'),
+      fetchApi<{ id: string; name: string }[]>('/api/zone-types'),
+      fetchApi<{ id: string; name: string }[]>('/api/regions'),
+      fetchApi<{ id: string; name: string }[]>('/api/activities'),
+      fetchApi<{ id: string; name: string }[]>('/api/amenities'),
+    ])
+    if (z) {
+      setZones(z)
+      setCurrentPage(1)
     }
+    if (t) setZoneTypes(t)
+    if (r) setRegions(r)
+    if (a) setActivities(a)
+    if (m) setAmenities(m)
   }
   useEffect(() => { load() }, [])
 
@@ -38,69 +129,402 @@ export default function ZonesAdmin() {
     setForm({ ...form, [e.target.name]: e.target.value })
   }
 
+  const handleStatus = (value: string) => {
+    setForm({ ...form, status: value })
+  }
+
+  const handleZoneType = (value: string) => {
+    setForm({ ...form, zoneTypeId: value })
+  }
+
+  const handleRegion = (value: string) => {
+    setForm({ ...form, regionId: value })
+  }
+
+  const toggleActivity = (id: string) => {
+    setForm((f) => ({
+      ...f,
+      activityIds: f.activityIds.includes(id)
+        ? f.activityIds.filter((a) => a !== id)
+        : [...f.activityIds, id],
+    }))
+  }
+
+  const toggleAmenity = (id: string) => {
+    setForm((f) => ({
+      ...f,
+      amenityIds: f.amenityIds.includes(id)
+        ? f.amenityIds.filter((a) => a !== id)
+        : [...f.amenityIds, id],
+    }))
+  }
+
+  const addVertex = () => {
+    setForm((f) => ({
+      ...f,
+      vertices: [...f.vertices, { lambertX: '', lambertY: '' }],
+    }))
+  }
+
+  const updateVertex = (
+    index: number,
+    field: 'lambertX' | 'lambertY',
+    value: string
+  ) => {
+    setForm((f) => {
+      const verts = [...f.vertices]
+      verts[index] = { ...verts[index], [field]: value }
+      return { ...f, vertices: verts }
+    })
+  }
+
+  const removeVertex = (index: number) => {
+    setForm((f) => {
+      const verts = [...f.vertices]
+      verts.splice(index, 1)
+      return { ...f, vertices: verts }
+    })
+  }
+
+  const handleFiles = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return
+    const files = Array.from(e.target.files).map((file) => ({
+      file,
+      url: URL.createObjectURL(file),
+    }))
+    setImages((imgs) => [...imgs, ...files])
+    e.target.value = ''
+  }
+
+  const removeImage = (idx: number) => {
+    setImages((imgs) => {
+      const copy = [...imgs]
+      URL.revokeObjectURL(copy[idx].url)
+      copy.splice(idx, 1)
+      return copy
+    })
+  }
+
   async function submit(e: React.FormEvent) {
     e.preventDefault()
+    const body = {
+      name: form.name,
+      description: form.description || undefined,
+      address: form.address || undefined,
+      totalArea: form.totalArea ? parseFloat(form.totalArea) : undefined,
+      price: form.price ? parseFloat(form.price) : undefined,
+      status: form.status,
+      latitude: form.latitude ? parseFloat(form.latitude) : undefined,
+      longitude: form.longitude ? parseFloat(form.longitude) : undefined,
+      lambertX: form.lambertX ? parseFloat(form.lambertX) : undefined,
+      lambertY: form.lambertY ? parseFloat(form.lambertY) : undefined,
+      zoneTypeId: form.zoneTypeId || undefined,
+      regionId: form.regionId || undefined,
+      activityIds: form.activityIds,
+      amenityIds: form.amenityIds,
+      vertices: form.vertices.map((v, i) => ({
+        seq: i,
+        lambertX: v.lambertX ? parseFloat(v.lambertX) : 0,
+        lambertY: v.lambertY ? parseFloat(v.lambertY) : 0,
+      })),
+    }
     if (form.id) {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/zones/${form.id}`, {
+      await fetchApi(`/api/zones/${form.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: form.name, status: form.status })
+        body: JSON.stringify(body),
       })
     } else {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/zones`, {
+      await fetchApi('/api/zones', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: form.name, status: form.status })
+        body: JSON.stringify(body),
       })
     }
-    setForm({ id: '', name: '', status: 'AVAILABLE' })
+    setForm({
+      id: '',
+      name: '',
+      description: '',
+      address: '',
+      totalArea: '',
+      price: '',
+      status: 'AVAILABLE',
+      latitude: '',
+      longitude: '',
+      lambertX: '',
+      lambertY: '',
+      zoneTypeId: '',
+      regionId: '',
+      activityIds: [],
+      amenityIds: [],
+      vertices: [],
+    })
+    setImages([])
+    setOpen(false)
     load()
   }
 
   async function edit(z: Zone) {
-    setForm({ id: z.id, name: z.name, status: z.status })
+    setForm({
+      id: z.id,
+      name: z.name,
+      description: z.description ?? '',
+      address: z.address ?? '',
+      totalArea: z.totalArea?.toString() ?? '',
+      price: z.price?.toString() ?? '',
+      status: z.status,
+      latitude: z.latitude?.toString() ?? '',
+      longitude: z.longitude?.toString() ?? '',
+      lambertX: z.lambertX?.toString() ?? '',
+      lambertY: z.lambertY?.toString() ?? '',
+      zoneTypeId: z.zoneTypeId || '',
+      regionId: z.regionId || '',
+      activityIds: z.activities ? z.activities.map(a => a.activityId) : [],
+      amenityIds: z.amenities ? z.amenities.map(a => a.amenityId) : [],
+      vertices: z.vertices ? z.vertices.sort((a,b)=>a.seq-b.seq).map(v => ({
+        lambertX: v.lambertX.toString(),
+        lambertY: v.lambertY.toString(),
+      })) : [],
+    })
+    setImages([])
+    setOpen(true)
   }
 
   async function del(id: string) {
-    await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/zones/${id}`, { method: 'DELETE' })
+    await fetchApi(`/api/zones/${id}`, { method: 'DELETE' })
     load()
+  }
+
+  function addNew() {
+    setForm({
+      id: '',
+      name: '',
+      description: '',
+      address: '',
+      totalArea: '',
+      price: '',
+      status: 'AVAILABLE',
+      latitude: '',
+      longitude: '',
+      lambertX: '',
+      lambertY: '',
+      zoneTypeId: '',
+      regionId: '',
+      activityIds: [],
+      amenityIds: [],
+      vertices: [],
+    })
+    setImages([])
+    setOpen(true)
   }
 
   return (
     <div className="p-4 space-y-6">
-      <h1 className="text-xl font-bold">Gestion des Zones</h1>
+      <div className="flex justify-between items-center">
+        <h1 className="text-xl font-bold">Gestion des Zones</h1>
+        <Button onClick={addNew}>Ajouter</Button>
+      </div>
       <Card>
-        <CardContent className="divide-y">
-          {zones.map(zone => (
-            <div key={zone.id} className="flex justify-between items-center py-2">
-              <span>{zone.name}</span>
-              <div className="space-x-2">
-                <Button size="sm" onClick={() => edit(zone)}>Éditer</Button>
-                <Button size="sm" variant="destructive" onClick={() => del(zone.id)}>Supprimer</Button>
-              </div>
-            </div>
-          ))}
+        <CardContent className="overflow-x-auto p-0">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left">
+                <th className="p-2">Nom</th>
+                <th className="p-2">Statut</th>
+                <th className="p-2">Région</th>
+                <th className="p-2 w-32"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {zones
+                .slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage)
+                .map((zone) => (
+                <tr key={zone.id} className="border-b last:border-0">
+                  <td className="p-2 align-top">{zone.name}</td>
+                  <td className="p-2 align-top">{zone.status}</td>
+                  <td className="p-2 align-top">{zone.regionId}</td>
+                  <td className="p-2 space-x-2 whitespace-nowrap">
+                    <Button size="sm" onClick={() => edit(zone)}>Éditer</Button>
+                    <Button size="sm" variant="destructive" onClick={() => del(zone.id)}>
+                      Supprimer
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>{form.id ? 'Modifier une zone' : 'Nouvelle zone'}</CardTitle>
-        </CardHeader>
-        <CardContent>
+      <Pagination
+        totalItems={zones.length}
+        itemsPerPage={itemsPerPage}
+        currentPage={currentPage}
+        onPageChange={setCurrentPage}
+      />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{form.id ? 'Modifier une zone' : 'Nouvelle zone'}</DialogTitle>
+          </DialogHeader>
           <form onSubmit={submit} className="space-y-4">
             <div>
               <Label htmlFor="name">Nom</Label>
               <Input id="name" name="name" value={form.name} onChange={handleChange} required />
             </div>
             <div>
+              <Label htmlFor="description">Description</Label>
+              <Input id="description" name="description" value={form.description} onChange={handleChange} />
+            </div>
+            <div>
+              <Label htmlFor="address">Adresse</Label>
+              <Input id="address" name="address" value={form.address} onChange={handleChange} />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="totalArea">Superficie m²</Label>
+                <Input id="totalArea" name="totalArea" value={form.totalArea} onChange={handleChange} />
+              </div>
+              <div>
+                <Label htmlFor="price">Prix DH/m²</Label>
+                <Input id="price" name="price" value={form.price} onChange={handleChange} />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="latitude">Latitude</Label>
+                <Input id="latitude" name="latitude" value={form.latitude} onChange={handleChange} />
+              </div>
+              <div>
+                <Label htmlFor="longitude">Longitude</Label>
+                <Input id="longitude" name="longitude" value={form.longitude} onChange={handleChange} />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="lambertX">Lambert X</Label>
+                <Input id="lambertX" name="lambertX" value={form.lambertX} onChange={handleChange} />
+              </div>
+              <div>
+                <Label htmlFor="lambertY">Lambert Y</Label>
+                <Input id="lambertY" name="lambertY" value={form.lambertY} onChange={handleChange} />
+              </div>
+            </div>
+            <div>
+              <Label>Coordonnées Lambert (polygone)</Label>
+              {form.vertices.map((v, idx) => (
+                <div key={idx} className="grid grid-cols-2 gap-2 items-center mb-2">
+                  <Input
+                    placeholder="X"
+                    value={v.lambertX}
+                    onChange={(e) => updateVertex(idx, 'lambertX', e.target.value)}
+                  />
+                  <div className="flex gap-2">
+                    <Input
+                      placeholder="Y"
+                      value={v.lambertY}
+                      onChange={(e) => updateVertex(idx, 'lambertY', e.target.value)}
+                    />
+                    <Button type="button" size="sm" variant="destructive" onClick={() => removeVertex(idx)}>
+                      ×
+                    </Button>
+                  </div>
+                </div>
+              ))}
+              <Button type="button" size="sm" onClick={addVertex}>Ajouter un point</Button>
+            </div>
+            <div>
               <Label htmlFor="status">Statut</Label>
-              <Input id="status" name="status" value={form.status} onChange={handleChange} />
+              <Select value={form.status} onValueChange={handleStatus}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Choisir" />
+                </SelectTrigger>
+                <SelectContent>
+                  {statuses.map((s) => (
+                    <SelectItem key={s} value={s}>{s}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor="zoneTypeId">Type</Label>
+              <Select value={form.zoneTypeId} onValueChange={handleZoneType}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Choisir" />
+                </SelectTrigger>
+                <SelectContent>
+                  {zoneTypes.map((t) => (
+                    <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor="regionId">Région</Label>
+              <Select value={form.regionId} onValueChange={handleRegion}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Choisir" />
+                </SelectTrigger>
+                <SelectContent>
+                  {regions.map((r) => (
+                    <SelectItem key={r.id} value={r.id}>{r.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label>Activités</Label>
+              <div className="flex flex-wrap gap-2">
+                {activities.map((a) => (
+                  <label key={a.id} className="flex items-center space-x-1">
+                    <input
+                      type="checkbox"
+                      checked={form.activityIds.includes(a.id)}
+                      onChange={() => toggleActivity(a.id)}
+                    />
+                    <span>{a.name}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+            <div>
+              <Label>Équipements</Label>
+              <div className="flex flex-wrap gap-2">
+                {amenities.map((a) => (
+                  <label key={a.id} className="flex items-center space-x-1">
+                    <input
+                      type="checkbox"
+                      checked={form.amenityIds.includes(a.id)}
+                      onChange={() => toggleAmenity(a.id)}
+                    />
+                    <span>{a.name}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+            <div>
+              <Label>Photos</Label>
+              <Input type="file" multiple onChange={handleFiles} />
+              <div className="flex flex-wrap gap-2 mt-2">
+                {images.map((img, idx) => (
+                  <div key={idx} className="relative">
+                    <img src={img.url} className="w-24 h-24 object-cover rounded" />
+                    <button
+                      type="button"
+                      onClick={() => removeImage(idx)}
+                      className="absolute top-0 right-0 bg-red-600 text-white rounded-full w-5 h-5 flex items-center justify-center"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
             </div>
             <Button type="submit">{form.id ? 'Mettre à jour' : 'Créer'}</Button>
           </form>
-        </CardContent>
-      </Card>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/Front-End/src/app/api/auth/[...nextauth]/route.ts
+++ b/Front-End/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,7 @@
+import NextAuth from 'next-auth'
+import { authOptions } from '@/lib/auth'
+
+const handler = NextAuth(authOptions)
+
+export { handler as GET, handler as POST }
+

--- a/Front-End/src/app/auth/register/page.tsx
+++ b/Front-End/src/app/auth/register/page.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { fetchApi } from '@/lib/utils';
 import { Building2, Eye, EyeOff, AlertCircle, CheckCircle } from 'lucide-react';
 import Link from 'next/link';
 
@@ -51,8 +52,7 @@ export default function RegisterPage() {
     }
 
     try {
-      const base = process.env.NEXT_PUBLIC_API_URL || '';
-      const response = await fetch(`${base}/api/auth/register`, {
+      const response = await fetchApi('/api/auth/register', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -66,11 +66,10 @@ export default function RegisterPage() {
         }),
       });
 
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.message || 'Erreur lors de l\'inscription');
+      if (!response) {
+        throw new Error('Erreur lors de l\'inscription');
       }
+      const data = response;
 
       setSuccess(true);
 

--- a/Front-End/src/app/contact/page.tsx
+++ b/Front-End/src/app/contact/page.tsx
@@ -1,0 +1,24 @@
+'use client'
+import { useState } from 'react'
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { Button } from '@/components/ui/button'
+import AppointmentForm from '@/components/AppointmentForm'
+
+export default function ContactPage() {
+  const [open, setOpen] = useState(false)
+  return (
+    <main className="min-h-screen flex flex-col">
+      <Header />
+      <div className="flex-grow container mx-auto px-4 py-12 space-y-6 text-center">
+        <h1 className="text-3xl font-bold">Contactez-nous</h1>
+        <p>Vous souhaitez proposer une nouvelle zone industrielle ? Prenez rendez-vous avec notre équipe.</p>
+        <Button className="header-red text-white" onClick={() => setOpen(true)}>
+          Prise de rendez-vous
+        </Button>
+      </div>
+      <Footer />
+      {open && <AppointmentForm onClose={() => setOpen(false)} />}
+    </main>
+  )
+}

--- a/Front-End/src/components/AdminHeader.tsx
+++ b/Front-End/src/components/AdminHeader.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import Link from 'next/link'
+
+export default function AdminHeader() {
+  return (
+    <header className="bg-white shadow-sm border-b">
+      <div className="container mx-auto px-4 h-12 flex items-center justify-end">
+        <Link
+          href="/admin"
+          className="text-sm text-gray-700 hover:text-red-600"
+        >
+          Retour au dashboard
+        </Link>
+      </div>
+    </header>
+  )
+}

--- a/Front-End/src/components/AppointmentForm.tsx
+++ b/Front-End/src/components/AppointmentForm.tsx
@@ -5,13 +5,19 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
+import { fetchApi } from '@/lib/utils'
 
 interface Parcel {
   id: string
   reference: string
 }
 
-export default function AppointmentForm({ parcel, onClose }: { parcel: Parcel; onClose: () => void }) {
+interface Props {
+  parcel?: Parcel
+  onClose: () => void
+}
+
+export default function AppointmentForm({ parcel, onClose }: Props) {
   const [open, setOpen] = useState(true)
   const [contactName, setContactName] = useState('')
   const [contactEmail, setContactEmail] = useState('')
@@ -19,10 +25,10 @@ export default function AppointmentForm({ parcel, onClose }: { parcel: Parcel; o
 
   async function submit(e: React.FormEvent) {
     e.preventDefault()
-    await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/appointments`, {
+    await fetchApi('/api/appointments', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ contactName, contactEmail, message, parcelId: parcel.id })
+      body: JSON.stringify({ contactName, contactEmail, message, parcelId: parcel?.id })
     })
     setOpen(false)
     onClose()
@@ -32,7 +38,9 @@ export default function AppointmentForm({ parcel, onClose }: { parcel: Parcel; o
     <Dialog open={open} onOpenChange={(o) => { setOpen(o); if (!o) onClose() }}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Prendre rendez-vous – {parcel.reference}</DialogTitle>
+          <DialogTitle>
+            Prendre rendez-vous{parcel ? ` – ${parcel.reference}` : ''}
+          </DialogTitle>
         </DialogHeader>
         <form onSubmit={submit} className="space-y-4">
           <div>

--- a/Front-End/src/components/Footer.tsx
+++ b/Front-End/src/components/Footer.tsx
@@ -1,44 +1,14 @@
 'use client';
 
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { Separator } from '@/components/ui/separator';
 import { Phone, Calendar, Mail, Facebook, Youtube, Instagram, Twitter, Building2 } from 'lucide-react';
+import AppointmentForm from './AppointmentForm';
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
+  const [showForm, setShowForm] = useState(false);
 
-  const productLinks = [
-    { title: 'Zones Industrielles', href: '/zones' },
-    { title: 'Parcs Logistiques', href: '/logistique' },
-    { title: 'Zones Franches', href: '/zones-franches' },
-    { title: 'Catalogues', href: '/catalogues' },
-  ];
-
-  const serviceLinks = [
-    { title: 'Service Client B2B', href: '/support' },
-    { title: 'Prise de Rendez-vous', href: '/rdv' },
-    { title: 'Simulation de Coûts', href: '/simulation' },
-    { title: 'Demandes d\'Informations', href: '/contact' },
-    { title: 'Appels d\'Offres', href: '/offres' },
-  ];
-
-  const supportLinks = [
-    { title: 'Déposer une Demande', href: '/support/demande' },
-    { title: 'Suivi des Demandes', href: '/support/suivi' },
-  ];
-
-  const networkLinks = [
-    { title: 'Région Casablanca-Settat', href: '/casablanca' },
-    { title: 'Région Rabat-Salé-Kénitra', href: '/rabat' },
-    { title: 'Région Fès-Meknès', href: '/fes' },
-    { title: 'Région Marrakech-Safi', href: '/marrakech' },
-    { title: 'Région Tanger-Tétouan', href: '/tanger' },
-    { title: 'Région Souss-Massa', href: '/agadir' },
-    { title: 'Région Oriental', href: '/oriental' },
-    { title: 'Région Darâa-Tafilalet', href: '/daraa' },
-    { title: 'Région Beni Mellal-Khénifra', href: '/beni-mellal' },
-    { title: 'Région Rabat-Salé-Kénitra', href: '/rabat' },
-  ];
 
   const mediaLinks = [
     { title: 'Communiqués de presse', href: '/media/communiques' },
@@ -56,6 +26,7 @@ export default function Footer() {
   ];
 
   return (
+    <>
     <footer className="bg-gray-800 text-white">
       {/* Action buttons */}
       <div className="bg-gray-700 py-6">
@@ -69,7 +40,10 @@ export default function Footer() {
               <Mail className="w-5 h-5" />
               Être contacté
             </Button>
-            <Button className="header-red text-white hover:opacity-90 flex items-center gap-2">
+            <Button
+              className="header-red text-white hover:opacity-90 flex items-center gap-2"
+              onClick={() => setShowForm(true)}
+            >
               <Calendar className="w-5 h-5" />
               Prise de rendez-vous
             </Button>
@@ -79,67 +53,6 @@ export default function Footer() {
 
       {/* Main footer content */}
       <div className="container mx-auto px-4 py-12">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-          {/* Nos Zones */}
-          <div>
-            <h3 className="text-lg font-semibold mb-4">Nos Zones</h3>
-            <ul className="space-y-2">
-              {productLinks.map((link, index) => (
-                <li key={index}>
-                  <a href={link.href} className="text-gray-300 hover:text-white transition-colors text-sm">
-                    {link.title}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {/* Services B2B */}
-          <div>
-            <h3 className="text-lg font-semibold mb-4">Services B2B</h3>
-            <ul className="space-y-2">
-              {serviceLinks.map((link, index) => (
-                <li key={index}>
-                  <a href={link.href} className="text-gray-300 hover:text-white transition-colors text-sm">
-                    {link.title}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {/* Support */}
-          <div>
-            <h3 className="text-lg font-semibold mb-4">Support</h3>
-            <ul className="space-y-2">
-              {supportLinks.map((link, index) => (
-                <li key={index}>
-                  <a href={link.href} className="text-gray-300 hover:text-white transition-colors text-sm">
-                    {link.title}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {/* Notre Réseau */}
-          <div>
-            <h3 className="text-lg font-semibold mb-4">Notre Réseau</h3>
-            <ul className="space-y-2 max-h-48 overflow-y-auto">
-              {networkLinks.map((link, index) => (
-                <li key={index}>
-                  <a href={link.href} className="text-gray-300 hover:text-white transition-colors text-sm">
-                    {link.title}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-
-        <Separator className="my-8 bg-gray-600" />
-
-        {/* Second row */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
           {/* Média */}
           <div>
@@ -193,7 +106,10 @@ export default function Footer() {
                 <Phone className="w-4 h-4 text-red-400" />
                 <span className="text-xl font-bold">+212 5 37 57 20 00</span>
               </div>
-              <Button className="w-full header-red text-white hover:opacity-90 mt-3">
+              <Button
+                className="w-full header-red text-white hover:opacity-90 mt-3"
+                onClick={() => setShowForm(true)}
+              >
                 Prise de rendez-vous
               </Button>
             </div>
@@ -214,13 +130,12 @@ export default function Footer() {
               <a href="/actualites" className="text-gray-300 hover:text-white">Actualités</a>
               <a href="/evenements" className="text-gray-300 hover:text-white">Événements</a>
               <a href="/mediatheque" className="text-gray-300 hover:text-white">Médiathèque</a>
-              <a href="/contact" className="text-gray-300 hover:text-white">Contactez nous</a>
-              <a href="/sitemap" className="text-gray-300 hover:text-white">Plan de site</a>
-              <a href="/faq" className="text-gray-300 hover:text-white">FAQ</a>
             </div>
           </div>
         </div>
       </div>
     </footer>
+    {showForm && <AppointmentForm onClose={() => setShowForm(false)} />}
+    </>
   );
 }

--- a/Front-End/src/components/Header.tsx
+++ b/Front-End/src/components/Header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { NavigationMenu, NavigationMenuContent, NavigationMenuItem, NavigationMenuLink, NavigationMenuList, NavigationMenuTrigger } from '@/components/ui/navigation-menu';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
@@ -8,45 +9,33 @@ import { Badge } from '@/components/ui/badge';
 import { Menu, Phone, MapPin, Building2 } from 'lucide-react';
 import AuthButton from '@/components/AuthButton';
 
-export default function Header() {
+export default function Header({ showAdminLink = false }: { showAdminLink?: boolean }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const mediaLinks = [
+    { title: 'Communiqués de presse', href: '/media/communiques' },
+    { title: 'Actualités', href: '/media/actualites' },
+    { title: 'Rapports', href: '/media/rapports' },
+  ];
+
+  const groupLinks = [
+    { title: 'À propos', href: '/groupe/a-propos' },
+    { title: 'Chiffres clés', href: '/groupe/chiffres' },
+    { title: 'Engagement citoyen', href: '/groupe/engagement' },
+    { title: 'Offre d\'emplois', href: '/groupe/emplois' },
+    { title: 'Candidature', href: '/groupe/candidature' },
+    { title: 'Politique de recrutement', href: '/groupe/recrutement' },
+  ];
 
   const navItems = [
     {
-      title: 'Nos Zones',
-      items: [
-        { title: 'Zones Industrielles', href: '/zones' },
-        { title: 'Parcs Logistiques', href: '/logistique' },
-        { title: 'Zones Franches', href: '/zones-franches' },
-        { title: 'Catalogues', href: '/catalogues' },
-      ]
+      title: 'Média',
+      items: mediaLinks,
     },
     {
-      title: 'Services B2B',
-      items: [
-        { title: 'Prise de Rendez-vous', href: '/rdv' },
-        { title: 'Simulation de Coûts', href: '/simulation' },
-        { title: 'Demande d\'Informations', href: '/contact' },
-        { title: 'Appels d\'Offres', href: '/offres' },
-      ]
+      title: 'Le Groupe',
+      items: groupLinks,
     },
-    {
-      title: 'Support',
-      items: [
-        { title: 'Service Client', href: '/support' },
-        { title: 'Suivi des Demandes', href: '/suivi' },
-      ]
-    },
-    {
-      title: 'Notre Réseau',
-      items: [
-        { title: 'Région Casablanca-Settat', href: '/casablanca' },
-        { title: 'Région Rabat-Salé-Kénitra', href: '/rabat' },
-        { title: 'Région Fès-Meknès', href: '/fes' },
-        { title: 'Région Marrakech-Safi', href: '/marrakech' },
-        { title: 'Région Tanger-Tétouan', href: '/tanger' },
-      ]
-    }
   ];
 
   return (
@@ -114,7 +103,12 @@ export default function Header() {
             </NavigationMenu>
 
             {/* Authentication section */}
-            <div className="hidden md:flex">
+            <div className="hidden md:flex items-center gap-4">
+              {showAdminLink && (
+                <Link href="/admin" className="text-sm text-gray-700 hover:text-red-600">
+                  Dashboard admin
+                </Link>
+              )}
               <AuthButton />
             </div>
 
@@ -128,7 +122,16 @@ export default function Header() {
               <SheetContent side="right">
                 <div className="space-y-4 py-4">
                   {/* Mobile Auth */}
-                  <div className="pb-4 border-b">
+                  <div className="pb-4 border-b space-y-2">
+                    {showAdminLink && (
+                      <a
+                        href="/admin"
+                        className="block text-sm text-gray-600 hover:text-red-600"
+                        onClick={() => setIsMenuOpen(false)}
+                      >
+                        Dashboard admin
+                      </a>
+                    )}
                     <AuthButton />
                   </div>
 

--- a/Front-End/src/components/MapView.tsx
+++ b/Front-End/src/components/MapView.tsx
@@ -2,34 +2,39 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
-import { MapContainer, TileLayer, Marker, Popup, FeatureGroup } from 'react-leaflet'
-import { EditControl } from 'react-leaflet-draw'
-import type { LeafletEvent } from 'leaflet'
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
 import 'leaflet/dist/leaflet.css'
-import 'leaflet-draw/dist/leaflet.draw.css'
+import { fetchApi } from '@/lib/utils'
 
-type GeoFeature = {
+type ZoneFeature = {
   geometry: { type: string; coordinates: [number, number] }
-  properties: Record<string, unknown>
+  properties: {
+    id: string
+    name: string
+    status: string
+    availableParcels: number
+    activityIcons: string[]
+  }
+}
+
+type ParcelFeature = {
+  geometry: { type: string; coordinates: [number, number] }
+  properties: { id: string; reference: string }
 }
 
 export default function MapView() {
-  const [zones, setZones] = useState<GeoFeature[]>([])
-  const [parcels, setParcels] = useState<GeoFeature[]>([])
+  const [zones, setZones] = useState<ZoneFeature[]>([])
+  const [parcels, setParcels] = useState<ParcelFeature[]>([])
 
   useEffect(() => {
-    const base = process.env.NEXT_PUBLIC_API_URL || ''
-    fetch(`${base}/api/map/zones`).then(r => r.json()).then(d => setZones(d.features)).catch(console.error)
-    fetch(`${base}/api/map/parcels`).then(r => r.json()).then(d => setParcels(d.features)).catch(console.error)
+    fetchApi<{ features: ZoneFeature[] }>("/api/map/zones")
+      .then((d) => d && setZones(d.features))
+      .catch(console.error)
+    fetchApi<{ features: ParcelFeature[] }>("/api/map/parcels")
+      .then((d) => d && setParcels(d.features))
+      .catch(console.error)
   }, [])
 
-  function handleCreate(e: LeafletEvent) {
-    const layer = (e as unknown as { layer?: { getLatLngs?: () => unknown } }).layer
-    if (layer && layer.getLatLngs) {
-      // In a real app, send polygon coordinates to the API
-      console.log('New polygon', layer.getLatLngs())
-    }
-  }
 
   return (
     <MapContainer center={[31.5, -7.5]} zoom={6} style={{ height: 600, width: '100%' }}>
@@ -38,12 +43,28 @@ export default function MapView() {
         id="mapbox/streets-v11"
       />
       {zones.map(z => (
-        <Marker key={z.properties.id} position={[z.geometry.coordinates[1], z.geometry.coordinates[0]]}>
+        <Marker
+          key={z.properties.id}
+          position={[z.geometry.coordinates[1], z.geometry.coordinates[0]]}
+        >
           <Popup>
-            <div className="space-y-1">
-              <strong>{z.properties.name}</strong>
+            <div className="space-y-1 text-sm">
+              <strong className="block mb-1">{z.properties.name}</strong>
               <div>Statut: {z.properties.status}</div>
-              <Link href={`/zones/${z.properties.id}`} className="text-blue-600 underline">Voir la zone</Link>
+              <div>Parcelles disponibles: {z.properties.availableParcels}</div>
+              {z.properties.activityIcons.length > 0 && (
+                <div className="flex gap-1 text-lg">
+                  {z.properties.activityIcons.map((ic, i) => (
+                    <span key={i}>{ic}</span>
+                  ))}
+                </div>
+              )}
+              <Link
+                href={`/zones/${z.properties.id}`}
+                className="text-blue-600 underline block mt-1"
+              >
+                Voir la zone
+              </Link>
             </div>
           </Popup>
         </Marker>
@@ -53,13 +74,6 @@ export default function MapView() {
           <Popup>Parcelle {p.properties.reference}</Popup>
         </Marker>
       ))}
-      <FeatureGroup>
-        <EditControl
-          position="topright"
-          onCreated={handleCreate}
-          draw={{ rectangle: false, circle: false, circlemarker: false, marker: false, polyline: false }}
-        />
-      </FeatureGroup>
     </MapContainer>
   )
 }

--- a/Front-End/src/components/Pagination.tsx
+++ b/Front-End/src/components/Pagination.tsx
@@ -1,0 +1,48 @@
+import { Button } from './ui/button'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+interface PaginationProps {
+  totalItems: number
+  itemsPerPage: number
+  currentPage: number
+  onPageChange: (page: number) => void
+}
+
+export default function Pagination({ totalItems, itemsPerPage, currentPage, onPageChange }: PaginationProps) {
+  const totalPages = Math.ceil(totalItems / itemsPerPage)
+  if (totalPages <= 1) return null
+  const pages = Array.from({ length: totalPages }, (_, i) => i + 1)
+  return (
+    <div className="flex items-center justify-center space-x-2 pt-4">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => onPageChange(Math.max(currentPage - 1, 1))}
+        disabled={currentPage === 1}
+      >
+        <ChevronLeft className="w-4 h-4 mr-1" />Page précédente
+      </Button>
+      <div className="flex space-x-1">
+        {pages.map(p => (
+          <Button
+            key={p}
+            variant={p === currentPage ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => onPageChange(p)}
+            className={p === currentPage ? 'header-red text-white' : ''}
+          >
+            {p}
+          </Button>
+        ))}
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => onPageChange(Math.min(currentPage + 1, totalPages))}
+        disabled={currentPage === totalPages}
+      >
+        Page suivante <ChevronRight className="w-4 h-4 ml-1" />
+      </Button>
+    </div>
+  )
+}

--- a/Front-End/src/components/SearchBar.tsx
+++ b/Front-End/src/components/SearchBar.tsx
@@ -1,218 +1,141 @@
 'use client';
 
-import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Search, MapPin, Factory, DollarSign, Ruler } from 'lucide-react';
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Search, MapPin, Factory } from 'lucide-react'
+import { fetchApi } from '@/lib/utils'
 
-export default function SearchBar() {
-  const [searchFilters, setSearchFilters] = useState({
-    region: '',
-    ville: '',
-    typeZone: '',
-    budget: '',
-    superficie: '',
-    typeIndustrie: '',
-    etatProjet: ''
-  });
+interface Filters {
+  regionId: string
+  zoneTypeId: string
+  status: string
+  minArea: string
+  maxArea: string
+  minPrice: string
+  maxPrice: string
+}
+export default function SearchBar({ onSearch }: { onSearch?: (f: Filters) => void }) {
+  const router = useRouter()
+  const [filters, setFilters] = useState<Filters>({
+    regionId: '',
+    zoneTypeId: '',
+    status: '',
+    minArea: '',
+    maxArea: '',
+    minPrice: '',
+    maxPrice: '',
+  })
 
-  const regions = [
-    'Casablanca-Settat',
-    'Rabat-Salé-Kénitra',
-    'Fès-Meknès',
-    'Marrakech-Safi',
-    'Tanger-Tétouan-Al Hoceïma',
-    'Souss-Massa',
-    'Oriental',
-    'Darâa-Tafilalet',
-    'Beni Mellal-Khénifra',
-    'Guelmim-Oued Noun',
-    'Laâyoune-Sakia El Hamra',
-    'Dakhla-Oued Ed-Dahab'
-  ];
+  const [regions, setRegions] = useState<{ id: string; name: string }[]>([])
+  const [zoneTypes, setZoneTypes] = useState<{ id: string; name: string }[]>([])
+  const statuses = ['AVAILABLE', 'RESERVED', 'OCCUPIED', 'SHOWROOM']
 
-  const typesZone = [
-    'Zone Industrielle',
-    'Parc Logistique',
-    'Zone Franche',
-    'Technopole',
-    'Zone Agroalimentaire',
-    'Zone Textile',
-    'Zone Automobile',
-    'Zone Pharmaceutique'
-  ];
+  useEffect(() => {
+    async function load() {
+      const [r, t] = await Promise.all([
+        fetchApi<{ id: string; name: string }[]>('/api/regions'),
+        fetchApi<{ id: string; name: string }[]>('/api/zone-types'),
+      ])
+      if (r) setRegions(r)
+      if (t) setZoneTypes(t)
+    }
+    load()
+  }, [])
 
-  const typesIndustrie = [
-    'Automobile',
-    'Textile',
-    'Agroalimentaire',
-    'Pharmaceutique',
-    'Électronique',
-    'Métallurgie',
-    'Chimie',
-    'Logistique',
-    'Technologies',
-    'Énergies Renouvelables'
-  ];
-
-  const etatsProjet = [
-    'Disponible',
-    'En cours de développement',
-    'Livraison prochaine',
-    'Réservé',
-    'Vendu'
-  ];
-
-  const budgetRanges = [
-    '< 500 000 DH',
-    '500 000 - 1 000 000 DH',
-    '1 000 000 - 5 000 000 DH',
-    '5 000 000 - 10 000 000 DH',
-    '> 10 000 000 DH'
-  ];
-
-  const superficieRanges = [
-    '< 1 000 m²',
-    '1 000 - 5 000 m²',
-    '5 000 - 10 000 m²',
-    '10 000 - 50 000 m²',
-    '> 50 000 m²'
-  ];
+  const handleSearch = () => {
+    onSearch?.(filters)
+    const params = new URLSearchParams()
+    if (filters.regionId) params.set('regionId', filters.regionId)
+    if (filters.zoneTypeId) params.set('zoneTypeId', filters.zoneTypeId)
+    if (filters.status) params.set('status', filters.status)
+    if (filters.minArea) params.set('minArea', filters.minArea)
+    if (filters.maxArea) params.set('maxArea', filters.maxArea)
+    if (filters.minPrice) params.set('minPrice', filters.minPrice)
+    if (filters.maxPrice) params.set('maxPrice', filters.maxPrice)
+    router.push(`/?${params.toString()}`)
+  }
 
   return (
     <div className="w-full bg-white shadow-lg rounded-lg p-6 mb-8">
       <div className="text-center mb-6">
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">
-          Trouvez votre zone industrielle
-        </h2>
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">Trouvez votre zone industrielle</h2>
         <p className="text-gray-600">Recherchez parmi nos zones industrielles disponibles</p>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-        {/* Région */}
         <div className="space-y-2">
           <label className="text-sm font-medium text-gray-700 flex items-center gap-2">
-            <MapPin className="w-4 h-4 text-red-600" />
-            Région
+            <MapPin className="w-4 h-4 text-red-600" /> Région
           </label>
-          <Select value={searchFilters.region} onValueChange={(value) => setSearchFilters({...searchFilters, region: value})}>
-            <SelectTrigger>
-              <SelectValue placeholder="Choisissez" />
-            </SelectTrigger>
+          <Select value={filters.regionId} onValueChange={(v) => setFilters({ ...filters, regionId: v })}>
+            <SelectTrigger><SelectValue placeholder="Choisissez" /></SelectTrigger>
             <SelectContent>
-              {regions.map((region) => (
-                <SelectItem key={region} value={region}>{region}</SelectItem>
+              {regions.map((r) => (
+                <SelectItem key={r.id} value={r.id}>{r.name}</SelectItem>
               ))}
             </SelectContent>
           </Select>
         </div>
 
-        {/* Ville */}
-        <div className="space-y-2">
-          <label className="text-sm font-medium text-gray-700">Ville</label>
-          <Input
-            placeholder="Choisissez"
-            value={searchFilters.ville}
-            onChange={(e) => setSearchFilters({...searchFilters, ville: e.target.value})}
-          />
-        </div>
-
-        {/* Type de Zone */}
         <div className="space-y-2">
           <label className="text-sm font-medium text-gray-700 flex items-center gap-2">
-            <Factory className="w-4 h-4 text-red-600" />
-            Type de Zone
+            <Factory className="w-4 h-4 text-red-600" /> Type
           </label>
-          <Select value={searchFilters.typeZone} onValueChange={(value) => setSearchFilters({...searchFilters, typeZone: value})}>
-            <SelectTrigger>
-              <SelectValue placeholder="Choisissez" />
-            </SelectTrigger>
+          <Select value={filters.zoneTypeId} onValueChange={(v) => setFilters({ ...filters, zoneTypeId: v })}>
+            <SelectTrigger><SelectValue placeholder="Choisissez" /></SelectTrigger>
             <SelectContent>
-              {typesZone.map((type) => (
-                <SelectItem key={type} value={type}>{type}</SelectItem>
+              {zoneTypes.map((t) => (
+                <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
               ))}
             </SelectContent>
           </Select>
         </div>
 
-        {/* Budget */}
         <div className="space-y-2">
-          <label className="text-sm font-medium text-gray-700 flex items-center gap-2">
-            <DollarSign className="w-4 h-4 text-red-600" />
-            Budget
-          </label>
-          <Select value={searchFilters.budget} onValueChange={(value) => setSearchFilters({...searchFilters, budget: value})}>
-            <SelectTrigger>
-              <SelectValue placeholder="Choisissez" />
-            </SelectTrigger>
+          <label className="text-sm font-medium text-gray-700">Statut</label>
+          <Select value={filters.status} onValueChange={(v) => setFilters({ ...filters, status: v })}>
+            <SelectTrigger><SelectValue placeholder="Choisissez" /></SelectTrigger>
             <SelectContent>
-              {budgetRanges.map((range) => (
-                <SelectItem key={range} value={range}>{range}</SelectItem>
+              {statuses.map((s) => (
+                <SelectItem key={s} value={s}>{s}</SelectItem>
               ))}
             </SelectContent>
           </Select>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-gray-700">Prix min</label>
+          <Input type="number" value={filters.minPrice} onChange={(e) => setFilters({ ...filters, minPrice: e.target.value })} />
+          <label className="text-sm font-medium text-gray-700">Prix max</label>
+          <Input type="number" value={filters.maxPrice} onChange={(e) => setFilters({ ...filters, maxPrice: e.target.value })} />
         </div>
       </div>
 
-      {/* Filtres avancés */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-        {/* Type d'Industrie */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
         <div className="space-y-2">
-          <label className="text-sm font-medium text-gray-700">Type d'Industrie</label>
-          <Select value={searchFilters.typeIndustrie} onValueChange={(value) => setSearchFilters({...searchFilters, typeIndustrie: value})}>
-            <SelectTrigger>
-              <SelectValue placeholder="Type d'Industrie" />
-            </SelectTrigger>
-            <SelectContent>
-              {typesIndustrie.map((type) => (
-                <SelectItem key={type} value={type}>{type}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <label className="text-sm font-medium text-gray-700">Superficie min (m²)</label>
+          <Input type="number" value={filters.minArea} onChange={(e) => setFilters({ ...filters, minArea: e.target.value })} />
         </div>
-
-        {/* Superficie */}
         <div className="space-y-2">
-          <label className="text-sm font-medium text-gray-700 flex items-center gap-2">
-            <Ruler className="w-4 h-4 text-red-600" />
-            Superficie
-          </label>
-          <Select value={searchFilters.superficie} onValueChange={(value) => setSearchFilters({...searchFilters, superficie: value})}>
-            <SelectTrigger>
-              <SelectValue placeholder="Superficie" />
-            </SelectTrigger>
-            <SelectContent>
-              {superficieRanges.map((range) => (
-                <SelectItem key={range} value={range}>{range}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        {/* État du Projet */}
-        <div className="space-y-2">
-          <label className="text-sm font-medium text-gray-700">État du Projet</label>
-          <Select value={searchFilters.etatProjet} onValueChange={(value) => setSearchFilters({...searchFilters, etatProjet: value})}>
-            <SelectTrigger>
-              <SelectValue placeholder="État de projet" />
-            </SelectTrigger>
-            <SelectContent>
-              {etatsProjet.map((etat) => (
-                <SelectItem key={etat} value={etat}>{etat}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <label className="text-sm font-medium text-gray-700">Superficie max (m²)</label>
+          <Input type="number" value={filters.maxArea} onChange={(e) => setFilters({ ...filters, maxArea: e.target.value })} />
         </div>
       </div>
 
-      {/* Bouton de recherche */}
       <div className="flex justify-center">
-        <Button className="search-blue text-white px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
-          <Search className="w-5 h-5 mr-2" />
-          Rechercher
+        <Button onClick={handleSearch} className="search-blue text-white px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
+          <Search className="w-5 h-5 mr-2" /> Rechercher
         </Button>
       </div>
     </div>
-  );
+  )
 }

--- a/Front-End/src/components/ZoneMap.tsx
+++ b/Front-End/src/components/ZoneMap.tsx
@@ -2,6 +2,7 @@
 
 import { MapContainer, TileLayer, Polygon, Popup } from "react-leaflet";
 import { useState } from "react";
+import proj4 from "proj4";
 import { Button } from "@/components/ui/button";
 import AppointmentForm from "@/components/AppointmentForm";
 
@@ -9,10 +10,12 @@ interface Parcel {
   id: string;
   reference: string;
   status: string;
+  isFree?: boolean;
   latitude: number | null;
   longitude: number | null;
   area?: number | null;
   price?: number | null;
+  vertices?: { seq: number; lambertX: number; lambertY: number }[];
 }
 
 interface Zone {
@@ -22,34 +25,52 @@ interface Zone {
   latitude: number | null;
   longitude: number | null;
   parcels: Parcel[];
+  vertices?: { seq: number; lambertX: number; lambertY: number }[];
 }
 
 export default function ZoneMap({ zone }: { zone: Zone }) {
   const [selected, setSelected] = useState<Parcel | null>(null);
 
+  const lambert93 =
+    '+proj=lcc +lat_1=44 +lat_2=49 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +units=m +no_defs';
+  const toLatLng = (x: number, y: number): [number, number] => {
+    const [lon, lat] = proj4(lambert93, proj4.WGS84, [x, y]);
+    return [lat, lon];
+  };
+
   if (zone.latitude == null || zone.longitude == null) return null;
 
-  const zonePolygon: [number, number][] = [
-    [zone.latitude + 0.01, zone.longitude - 0.01],
-    [zone.latitude + 0.01, zone.longitude + 0.01],
-    [zone.latitude - 0.01, zone.longitude + 0.01],
-    [zone.latitude - 0.01, zone.longitude - 0.01],
-  ];
+  const zonePolygon: [number, number][] = zone.vertices && zone.vertices.length
+    ? zone.vertices
+        .sort((a, b) => a.seq - b.seq)
+        .map((v) => toLatLng(v.lambertX, v.lambertY))
+    : [
+        [zone.latitude + 0.01, zone.longitude - 0.01],
+        [zone.latitude + 0.01, zone.longitude + 0.01],
+        [zone.latitude - 0.01, zone.longitude + 0.01],
+        [zone.latitude - 0.01, zone.longitude - 0.01],
+      ];
 
-  const size = 0.002;
-  const parcelPoly = (p: Parcel): [number, number][] => [
-    [p.latitude! + size, p.longitude! - size],
-    [p.latitude! + size, p.longitude! + size],
-    [p.latitude! - size, p.longitude! + size],
-    [p.latitude! - size, p.longitude! - size],
-  ];
+  const parcelPoly = (p: Parcel): [number, number][] =>
+    p.vertices && p.vertices.length
+      ? p.vertices
+          .sort((a, b) => a.seq - b.seq)
+          .map((v) => toLatLng(v.lambertX, v.lambertY))
+      : (() => {
+          const size = 0.002;
+          return [
+            [p.latitude! + size, p.longitude! - size],
+            [p.latitude! + size, p.longitude! + size],
+            [p.latitude! - size, p.longitude! + size],
+            [p.latitude! - size, p.longitude! - size],
+          ];
+        })();
 
   const zoneColor: Record<string, string> = {
     AVAILABLE: "green",
-    PARTIALLY_OCCUPIED: "orange",
-    FULLY_OCCUPIED: "red",
-    UNDER_DEVELOPMENT: "gray",
-    RESERVED: "red",
+    RESERVED: "orange",
+    OCCUPIED: "red",
+    SHOWROOM: "blue",
   };
 
   const parcelColor = (s: string) => {
@@ -72,7 +93,7 @@ export default function ZoneMap({ zone }: { zone: Zone }) {
       <MapContainer
         center={[zone.latitude, zone.longitude]}
         zoom={15}
-        style={{ height: 500, width: "100%" }}
+        style={{ height: 350, width: "100%" }}
       >
         <TileLayer
           url={`https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=${process.env.NEXT_PUBLIC_MAPBOX_TOKEN}`}
@@ -104,7 +125,7 @@ export default function ZoneMap({ zone }: { zone: Zone }) {
                     {p.area && <div>Surface: {p.area} m²</div>}
                     {p.price && <div>Prix: {p.price} DH</div>}
                     <div>Statut: {p.status}</div>
-                    {p.status === "AVAILABLE" && (
+                    {p.status === "AVAILABLE" && p.isFree && (
                       <Button
                         size="sm"
                         className="mt-1"

--- a/Front-End/src/components/ui/dialog.tsx
+++ b/Front-End/src/components/ui/dialog.tsx
@@ -38,13 +38,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background px-6 py-8 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg max-h-[90vh] overflow-y-auto",
         className
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute left-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/Front-End/src/lib/auth.ts
+++ b/Front-End/src/lib/auth.ts
@@ -1,6 +1,7 @@
 // Front-End/src/lib/auth.ts
 import { NextAuthOptions } from "next-auth"
 import CredentialsProvider from "next-auth/providers/credentials"
+import { fetchApi } from "./utils"
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -17,7 +18,7 @@ export const authOptions: NextAuthOptions = {
 
         try {
           // Appel à l'API backend pour l'authentification
-          const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/login`, {
+          const data = await fetchApi<{ user?: any }>("/api/auth/login", {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -26,12 +27,10 @@ export const authOptions: NextAuthOptions = {
             })
           })
 
-          const data = await res.json()
-
-          if (res.ok && data.user) {
+          if (data && data.user) {
             return data.user
           }
-          
+
           return null
         } catch (error) {
           console.error('Auth error:', error)

--- a/Front-End/src/lib/utils.ts
+++ b/Front-End/src/lib/utils.ts
@@ -4,3 +4,22 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function getBaseUrl() {
+  if (typeof window === 'undefined') {
+    return process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || '';
+  }
+  return process.env.NEXT_PUBLIC_API_URL || '';
+}
+
+export async function fetchApi<T>(path: string, init?: RequestInit): Promise<T | null> {
+  try {
+    const url = new URL(path, getBaseUrl())
+    const res = await fetch(url.toString(), init)
+    if (!res.ok) return null
+    return await res.json()
+  } catch (err) {
+    console.error(err)
+    return null
+  }
+}

--- a/README.md
+++ b/README.md
@@ -39,4 +39,40 @@ A `docker-compose.yml` file is provided at the repository root. After installing
 docker compose up --build
 ```
 
-This starts PostgreSQL, the API backend on port 3001 and the front-end on port 3000. An optional Nginx proxy listens on port 80.
+This starts PostgreSQL, the API backend on port 3001 and the front-end on port 3000.
+The front-end is built with `NEXT_PUBLIC_API_URL=http://localhost:3001` so your
+browser can reach the API directly on the host. When using Docker, the frontend
+server accesses the backend via `API_INTERNAL_URL=http://backend:3001`.
+An optional Nginx proxy listens on port 80.
+The backend adds CORS headers in each API route so the React app can call the API
+without extra configuration.
+
+### Manual database initialisation
+
+To execute the SQL script directly, run the helper inside `Back-End/scripts`.
+It automatically falls back to Docker if the `psql` command is not available:
+
+```bash
+cd Back-End
+export PGPASSWORD=postgres
+./scripts/run_initdb.sh
+```
+
+When using `docker compose`, the script will execute `psql` inside the `db` service.
+The SQL file now also creates demo users. Default logins are:
+
+```
+- admin@zonespro.ma / password123
+- manager@zonespro.ma / password123
+- demo@entreprise.ma / password123
+```
+Lambert polygon points are inserted into `zone_vertices` and `parcel_vertices`
+to allow drawing shapes for zones and parcels.
+
+You can also run the command manually:
+
+```bash
+PGPASSWORD=postgres docker compose exec db \
+  psql -U postgres -d industria \
+  -f /docker-entrypoint-initdb.d/initDB.sql
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,9 @@ services:
       - NODE_ENV=development
       - PORT=3000
       - HOSTNAME=0.0.0.0
-      - NEXT_PUBLIC_API_URL=http://backend:3001
+      # Exposed on localhost so the browser can reach the API
+      - NEXT_PUBLIC_API_URL=http://localhost:3001
+      - API_INTERNAL_URL=http://backend:3001
       - NEXTAUTH_URL=http://localhost:3000
       - NEXTAUTH_SECRET=supersecretkey123456789
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- close popups after saving forms in admin pages
- add Pagination component and paginate admin tables
- zone popups on the map now show activity icons and number of available parcels
- parcels now track availability states and map API reports free parcels
- prevent appointment creation unless parcel is available and free
- support filtering zones via query params and search form
- add contact page with appointment popup for new zones
- simplify header and footer navigation to only keep Media and Le Groupe links
- fix init script for older schemas
- centralize API fetch helper and use it across admin pages

## Testing
- `cd Back-End && npm install >/tmp/npm-backend.log && tail -n 20 /tmp/npm-backend.log`
- `cd ../Front-End && npm install >/tmp/npm-frontend.log && tail -n 20 /tmp/npm-frontend.log`


------
https://chatgpt.com/codex/tasks/task_e_68800744e3f4832ca4b158d548e5e174