### PR TITLE
Return lon/lat order for Lambert conversion

### DIFF
--- a/Back-End/prisma/seed.ts
+++ b/Back-End/prisma/seed.ts
@@ -221,8 +221,8 @@ async function main() {
         status: ZoneStatus.AVAILABLE,
         lambertX: 423456.78,
         lambertY: 372890.12,
-        latitude: lambertToWGS84(423456.78, 372890.12)[0],
-        longitude: lambertToWGS84(423456.78, 372890.12)[1],
+        latitude: lambertToWGS84(423456.78, 372890.12)[1],
+        longitude: lambertToWGS84(423456.78, 372890.12)[0],
         zoneTypeId: zoneTypes[0].id,
         regionId: regions[0].id,
       }
@@ -237,8 +237,8 @@ async function main() {
         status: ZoneStatus.OCCUPIED,
         lambertX: 445123.45,
         lambertY: 380567.89,
-        latitude: lambertToWGS84(445123.45, 380567.89)[0],
-        longitude: lambertToWGS84(445123.45, 380567.89)[1],
+        latitude: lambertToWGS84(445123.45, 380567.89)[1],
+        longitude: lambertToWGS84(445123.45, 380567.89)[0],
         zoneTypeId: zoneTypes[1].id,
         regionId: regions[0].id,
       }
@@ -253,8 +253,8 @@ async function main() {
         status: ZoneStatus.AVAILABLE,
         lambertX: 512345.67,
         lambertY: 412789.34,
-        latitude: lambertToWGS84(512345.67, 412789.34)[0],
-        longitude: lambertToWGS84(512345.67, 412789.34)[1],
+        latitude: lambertToWGS84(512345.67, 412789.34)[1],
+        longitude: lambertToWGS84(512345.67, 412789.34)[0],
         zoneTypeId: zoneTypes[0].id,
         regionId: regions[4].id,
       }
@@ -269,8 +269,8 @@ async function main() {
         status: ZoneStatus.RESERVED,
         lambertX: 467890.23,
         lambertY: 392456.78,
-        latitude: lambertToWGS84(467890.23, 392456.78)[0],
-        longitude: lambertToWGS84(467890.23, 392456.78)[1],
+        latitude: lambertToWGS84(467890.23, 392456.78)[1],
+        longitude: lambertToWGS84(467890.23, 392456.78)[0],
         zoneTypeId: zoneTypes[0].id,
         regionId: regions[1].id,
       }
@@ -286,7 +286,7 @@ async function main() {
   for (let i = 1; i <= 12; i++) {
     const lambertX = zones[0].lambertX! + (Math.random() - 0.5) * 100
     const lambertY = zones[0].lambertY! + (Math.random() - 0.5) * 100
-    const [lat, lon] = lambertToWGS84(lambertX, lambertY)
+    const [lon, lat] = lambertToWGS84(lambertX, lambertY)
     const parcel = await prisma.parcel.create({
       data: {
         reference: `CAS-${i.toString().padStart(3, '0')}`,
@@ -311,7 +311,7 @@ async function main() {
   for (let i = 1; i <= 15; i++) {
     const px = zones[1].lambertX! + (Math.random() - 0.5) * 100
     const py = zones[1].lambertY! + (Math.random() - 0.5) * 100
-    const [plat, plon] = lambertToWGS84(px, py)
+    const [plon, plat] = lambertToWGS84(px, py)
     const parcel = await prisma.parcel.create({
       data: {
         reference: `MOH-${i.toString().padStart(3, '0')}`,

--- a/Back-End/src/app/api/map/parcels/route.ts
+++ b/Back-End/src/app/api/map/parcels/route.ts
@@ -26,7 +26,7 @@ export async function GET() {
         const verts = p.vertices.sort((a, b) => a.seq - b.seq);
         const c = polygonCentroid(verts);
         if (c) {
-          ;[lat, lon] = lambertToWGS84(c[0], c[1]);
+          ;[lon, lat] = lambertToWGS84(c[0], c[1]);
         }
       }
       if (lat == null && p.latitude != null && p.longitude != null) {
@@ -34,7 +34,7 @@ export async function GET() {
         lon = p.longitude;
       }
       if (lat == null && p.lambertX != null && p.lambertY != null) {
-        ;[lat, lon] = lambertToWGS84(p.lambertX, p.lambertY);
+        ;[lon, lat] = lambertToWGS84(p.lambertX, p.lambertY);
       }
       if (lat == null || lon == null) return null;
       return {

--- a/Back-End/src/app/api/map/zones/route.ts
+++ b/Back-End/src/app/api/map/zones/route.ts
@@ -26,7 +26,7 @@ export async function GET() {
       const verts = z.vertices.sort((a, b) => a.seq - b.seq)
       const c = polygonCentroid(verts)
       if (c) {
-        ;[lat, lon] = lambertToWGS84(c[0], c[1])
+        ;[lon, lat] = lambertToWGS84(c[0], c[1])
       }
     }
     if (lat == null && z.latitude != null && z.longitude != null) {
@@ -34,7 +34,7 @@ export async function GET() {
       lon = z.longitude
     }
     if (lat == null && z.lambertX != null && z.lambertY != null) {
-      ;[lat, lon] = lambertToWGS84(z.lambertX, z.lambertY)
+      ;[lon, lat] = lambertToWGS84(z.lambertX, z.lambertY)
     }
     if (lat == null || lon == null) return null
     return {

--- a/Back-End/src/lib/coords.ts
+++ b/Back-End/src/lib/coords.ts
@@ -4,7 +4,7 @@ const lambertMA = '+proj=lcc +lat_1=33.3 +lat_2=35.1 +lat_0=33 +lon_0=-5.4 +x_0=
 
 export function lambertToWGS84(x: number, y: number): [number, number] {
   const [lon, lat] = proj4(lambertMA, proj4.WGS84, [x, y])
-  return [lat, lon]
+  return [lon, lat]
 }
 
 export function polygonCentroid(vertices: { lambertX: number, lambertY: number }[]): [number, number] | null {
@@ -40,7 +40,7 @@ export function addLatLonToParcel<T extends { lambertX: number | null | undefine
   if (parcel.vertices && parcel.vertices.length) {
     const verts = [...parcel.vertices].sort((a, b) => a.seq - b.seq)
     parcel.vertices = verts.map(v => {
-      const [lat, lon] = lambertToWGS84(v.lambertX, v.lambertY)
+      const [lon, lat] = lambertToWGS84(v.lambertX, v.lambertY)
       return { ...v, lat, lon }
     })
     const c = polygonCentroid(verts)
@@ -50,7 +50,7 @@ export function addLatLonToParcel<T extends { lambertX: number | null | undefine
     point = [parcel.lambertX, parcel.lambertY]
   }
   if (point) {
-    const [lat, lon] = lambertToWGS84(point[0], point[1])
+    const [lon, lat] = lambertToWGS84(point[0], point[1])
     ;(parcel as any).latitude = lat
     ;(parcel as any).longitude = lon
   }
@@ -61,18 +61,18 @@ export function addLatLonToZone<T extends { lambertX: number | null | undefined,
   if (zone.vertices && zone.vertices.length) {
     const verts = [...zone.vertices].sort((a, b) => a.seq - b.seq)
     zone.vertices = verts.map(v => {
-      const [lat, lon] = lambertToWGS84(v.lambertX, v.lambertY)
+      const [lon, lat] = lambertToWGS84(v.lambertX, v.lambertY)
       return { ...v, lat, lon }
     })
     const c = polygonCentroid(verts)
     if (c) {
-      const [lat, lon] = lambertToWGS84(c[0], c[1])
+      const [lon, lat] = lambertToWGS84(c[0], c[1])
       ;(zone as any).latitude = lat
       ;(zone as any).longitude = lon
     }
   }
   if ((zone as any).latitude == null && zone.lambertX != null && zone.lambertY != null) {
-    const [lat, lon] = lambertToWGS84(zone.lambertX, zone.lambertY)
+    const [lon, lat] = lambertToWGS84(zone.lambertX, zone.lambertY)
     ;(zone as any).latitude = lat
     ;(zone as any).longitude = lon
   }


### PR DESCRIPTION
## Summary
- return `[lon, lat]` from Lambert conversion helpers
- update backend and frontend call sites
- adjust seed script to the new order

## Testing
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68848ff9ccbc832c86566c7a1b13b0b2